### PR TITLE
FEAT: Greatly reduce time for Whittaker methods and make them more robust

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,12 +104,17 @@ and the following libraries:
 All of the required libraries should be automatically installed when
 installing pybaselines using either of the two installation methods below.
 
+Additionally, pybaselines has the following optional dependencies:
+
+* `pentapy <https://github.com/GeoStat-Framework/pentapy>`_ (>= 1.0):
+  provides a faster solver for Whittaker-smoothing-based methods
+
 
 Stable Release
 ~~~~~~~~~~~~~~
 
-pybaselines is easily installed using `pip <https://pip.pypa.io>`_, simply by running
-the following command in your terminal:
+pybaselines is easily installed from `pypi <https://pypi.org/project/pybaselines>`_
+using `pip <https://pip.pypa.io>`_, by running the following command in your terminal:
 
 .. code-block:: console
 
@@ -117,6 +122,12 @@ the following command in your terminal:
 
 This is the preferred method to install pybaselines, as it will always install the
 most recent stable release.
+
+To also install the optional dependencies when installing pybaselines, do:
+
+.. code-block:: console
+
+    pip install --upgrade pybaselines[full]
 
 
 Development Version

--- a/docs/_templates/autoapi/python/module.rst
+++ b/docs/_templates/autoapi/python/module.rst
@@ -55,7 +55,23 @@ Submodules
 
 {% set visible_classes = visible_children|selectattr("type", "equalto", "class")|list %}
 {% set visible_functions = visible_children|selectattr("type", "equalto", "function")|list %}
-{% if "show-module-summary" in autoapi_options and (visible_classes or visible_functions) %}
+{% set visible_attributes = visible_children|selectattr("type", "equalto", "data")|list %}
+{% if "show-module-summary" in autoapi_options and (visible_classes or visible_functions or visible_attributes) %}
+{% block attributes scoped %}
+{% if visible_attributes %}
+Attributes
+~~~~~~~~~~
+
+.. autoapisummary::
+
+{% for attribute in visible_attributes %}
+   {{ attribute.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+
 {% block classes scoped %}
 {% if visible_classes %}
 Classes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,8 @@ todo_include_todos = False
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None)
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'pentapy': ('https://geostat-framework.readthedocs.io/projects/pentapy/en/stable/', None)
 }
 
 # cache remote doc inventories for 14 days
@@ -130,6 +131,9 @@ autoapi_python_class_content = 'both' # include class docstring from both class 
 #autoapi_keep_files = True # keep the files after generation
 #autoapi_add_toctree_entry = False # need to manually add to toctree if False
 #autoapi_generate_api_docs = False # will not generate new docs when False
+
+# ignore an import warning from sphinx-autoapi due to double import of utils
+suppress_warnings = ['autoapi.python_import_resolution']
 
 # -- Options for HTML output -------------------------------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,15 +14,20 @@ pybaselines requires `Python <https://python.org>`_ version 3.6 or later and the
 * `SciPy <https://www.scipy.org/scipylib/index.html>`_ (>= 0.11)
 
 
-All of the required libraries should be automatically installed when installing pybaselines
-using either of the two installation methods below.
+All of the required libraries should be automatically installed when
+installing pybaselines using either of the two installation methods below.
+
+Additionally, pybaselines has the following optional dependencies:
+
+* `pentapy <https://github.com/GeoStat-Framework/pentapy>`_ (>= 1.0):
+  provides a faster solver for Whittaker-smoothing-based methods
 
 
 Stable Release
 ~~~~~~~~~~~~~~
 
 pybaselines is easily installed from `pypi <https://pypi.org/project/pybaselines>`_
-using `pip <https://pip.pypa.io>`_, simply by running the following command in your terminal:
+using `pip <https://pip.pypa.io>`_, by running the following command in your terminal:
 
 .. code-block:: console
 
@@ -32,6 +37,12 @@ This is the preferred method to install pybaselines, as it will always install t
 recent stable release. Note that the ``--upgrade`` tag is used to ensure that the
 most recent version of pybaselines is downloaded and installed, even if an older version
 is currently installed.
+
+To also install the optional dependencies when installing pybaselines, do:
+
+.. code-block:: console
+
+    pip install --upgrade pybaselines[full]
 
 
 Development Version

--- a/pybaselines/_algorithm_setup.py
+++ b/pybaselines/_algorithm_setup.py
@@ -222,7 +222,8 @@ def _diff_1_diags(data_size, upper_only=True, add_zeros=False):
     return output
 
 
-def _setup_whittaker(data, lam, diff_order=2, weights=None, copy_weights=False, upper_only=True):
+def _setup_whittaker(data, lam, diff_order=2, weights=None, copy_weights=False,
+                     upper_only=True, reverse_diags=False):
     """
     Sets the starting parameters for doing penalized least squares.
 
@@ -246,6 +247,9 @@ def _setup_whittaker(data, lam, diff_order=2, weights=None, copy_weights=False, 
     upper_only : boolean, optional
         If True (default), will include only the upper non-zero diagonals of
         the squared difference matrix. If False, will include all non-zero diagonals.
+    reverse_diags : boolean, optional
+        If True, will reverse the order of the diagonals of the squared difference
+        matrix. Default is False.
 
     Returns
     -------
@@ -294,6 +298,9 @@ def _setup_whittaker(data, lam, diff_order=2, weights=None, copy_weights=False, 
         diff_matrix = difference_matrix(num_y, diff_order, 'csc')
         diff_matrix = diff_matrix.T * diff_matrix
         diagonal_data = diff_matrix.todia().data[diff_order if upper_only else 0:][::-1]
+
+    if reverse_diags:
+        diagonal_data = diagonal_data[::-1]
 
     if weights is None:
         weight_array = np.ones(num_y)

--- a/pybaselines/morphological.py
+++ b/pybaselines/morphological.py
@@ -8,10 +8,10 @@ Created on March 5, 2021
 
 import numpy as np
 from scipy.ndimage import grey_closing, grey_dilation, grey_erosion, grey_opening, uniform_filter1d
-from scipy.sparse.linalg import spsolve
+from scipy.linalg import solve_banded
 
 from ._algorithm_setup import _optimize_window, _setup_morphology, _setup_whittaker
-from .utils import PERMC_SPEC, pad_edges, padded_convolve, relative_difference
+from .utils import pad_edges, padded_convolve, relative_difference
 
 
 # make _optimize_window available to users and document it so that
@@ -203,8 +203,13 @@ def mpls(data, half_window=None, lam=1e6, p=0.0, diff_order=2, tol=1e-3, max_ite
             index = np.argmin(y[previous_segment:next_segment + 1]) + previous_segment
             w[index] = 1 - p
 
-    _, diff_matrix, weight_matrix, weight_array = _setup_whittaker(y, lam, diff_order, w)
-    baseline = spsolve(weight_matrix + diff_matrix, weight_array * y, permc_spec=PERMC_SPEC)
+    _, diff_matrix, weight_array = _setup_whittaker(
+        y, lam, diff_order, w, 'csc', None, False
+    )
+
+    ddata = diff_matrix.todia().data[::-1]
+    ddata[diff_order] = ddata[diff_order] + weight_array
+    baseline = solve_banded((diff_order, diff_order), ddata, weight_array * y, overwrite_b=True)
 
     params = {'weights': weight_array, 'half_window': half_wind}
     return baseline, params

--- a/pybaselines/morphological.py
+++ b/pybaselines/morphological.py
@@ -203,13 +203,10 @@ def mpls(data, half_window=None, lam=1e6, p=0.0, diff_order=2, tol=1e-3, max_ite
             index = np.argmin(y[previous_segment:next_segment + 1]) + previous_segment
             w[index] = 1 - p
 
-    _, diff_matrix, weight_array = _setup_whittaker(y, lam, diff_order, w)
-
-    ddata = diff_matrix.todia().data[diff_order::-1]
-    ddata[0] = ddata[0] + weight_array
+    _, ddata, weight_array = _setup_whittaker(y, lam, diff_order, w)
+    ddata[-1] = ddata[-1] + weight_array
     baseline = solveh_banded(
-        ddata, weight_array * y, overwrite_ab=True, overwrite_b=True,
-        lower=True, check_finite=False
+        ddata, weight_array * y, overwrite_ab=True, overwrite_b=True, check_finite=False
     )
 
     params = {'weights': weight_array, 'half_window': half_wind}

--- a/pybaselines/morphological.py
+++ b/pybaselines/morphological.py
@@ -7,7 +7,7 @@ Created on March 5, 2021
 """
 
 import numpy as np
-from scipy.linalg import solve_banded
+from scipy.linalg import solveh_banded
 from scipy.ndimage import grey_closing, grey_dilation, grey_erosion, grey_opening, uniform_filter1d
 
 from ._algorithm_setup import _optimize_window, _setup_morphology, _setup_whittaker
@@ -205,9 +205,12 @@ def mpls(data, half_window=None, lam=1e6, p=0.0, diff_order=2, tol=1e-3, max_ite
 
     _, diff_matrix, weight_array = _setup_whittaker(y, lam, diff_order, w)
 
-    ddata = diff_matrix.todia().data[::-1]
-    ddata[diff_order] = ddata[diff_order] + weight_array
-    baseline = solve_banded((diff_order, diff_order), ddata, weight_array * y, overwrite_b=True)
+    ddata = diff_matrix.todia().data[diff_order::-1]
+    ddata[0] = ddata[0] + weight_array
+    baseline = solveh_banded(
+        ddata, weight_array * y, overwrite_ab=True, overwrite_b=True,
+        lower=True, check_finite=False
+    )
 
     params = {'weights': weight_array, 'half_window': half_wind}
     return baseline, params

--- a/pybaselines/morphological.py
+++ b/pybaselines/morphological.py
@@ -7,8 +7,8 @@ Created on March 5, 2021
 """
 
 import numpy as np
-from scipy.ndimage import grey_closing, grey_dilation, grey_erosion, grey_opening, uniform_filter1d
 from scipy.linalg import solve_banded
+from scipy.ndimage import grey_closing, grey_dilation, grey_erosion, grey_opening, uniform_filter1d
 
 from ._algorithm_setup import _optimize_window, _setup_morphology, _setup_whittaker
 from .utils import pad_edges, padded_convolve, relative_difference
@@ -203,9 +203,7 @@ def mpls(data, half_window=None, lam=1e6, p=0.0, diff_order=2, tol=1e-3, max_ite
             index = np.argmin(y[previous_segment:next_segment + 1]) + previous_segment
             w[index] = 1 - p
 
-    _, diff_matrix, weight_array = _setup_whittaker(
-        y, lam, diff_order, w, 'csc', None, False
-    )
+    _, diff_matrix, weight_array = _setup_whittaker(y, lam, diff_order, w)
 
     ddata = diff_matrix.todia().data[::-1]
     ddata[diff_order] = ddata[diff_order] + weight_array

--- a/pybaselines/utils.py
+++ b/pybaselines/utils.py
@@ -9,6 +9,28 @@ Created on March 5, 2021
 import numpy as np
 
 
+try:
+    from pentapy import solve as _pentapy_solve
+    _HAS_PENTAPY = True
+except ImportError:
+    _HAS_PENTAPY = False
+
+    def _pentapy_solve(*args, **kwargs):
+        """Dummy function in case pentapy is not installed."""
+        raise NotImplementedError('must have pentapy installed to use its solver')
+
+
+# Note: the triple quotes are for including the attributes within the documentation
+PENTAPY_SOLVER = 2
+"""An integer designating the solver to use if pentapy is installed.
+pentapy's solver can be used for solving pentadiagonal linear systems, such
+as those used for the Whittaker-smoothing-based algorithms. Should be 2 (default)
+or 1. See :func:`pentapy.core.solve` for more details.
+"""
+
+PERMC_SPEC = None
+"""A deprecated constant used in previous versions. Will be removed in v0.6.0."""
+
 # the minimum positive float values such that a + _MIN_FLOAT != a
 _MIN_FLOAT = np.finfo(float).eps
 

--- a/pybaselines/utils.py
+++ b/pybaselines/utils.py
@@ -4,24 +4,10 @@
 Created on March 5, 2021
 @author: Donald Erb
 
-Attributes
-----------
-PERMC_SPEC : str
-    A string indicating the method used for sparsity preservation when solving
-    sparse linear equations, such as those used for the Whittaker-smoothing-based
-    algorithms. See :func:`scipy.sparse.linalg.spsolve` for more information.
-    Default value is "NATURAL", which was ~5-35% faster for all Whittaker
-    functions compared to the other `permc_spec` options (tested on a computer with
-    Windows 10, Intel i5-7200U CPU, scipy version 1.6.1). Times may vary based on
-    computer os/architecture, number of data points, and the Whittaker-smoothing-based
-    function used.
-
 """
 
 import numpy as np
 
-
-PERMC_SPEC = 'NATURAL'
 
 # the minimum positive float values such that a + _MIN_FLOAT != a
 _MIN_FLOAT = np.finfo(float).eps

--- a/pybaselines/utils.py
+++ b/pybaselines/utils.py
@@ -225,3 +225,39 @@ def padded_convolve(data, kernel, mode='reflect', **pad_kwargs):
         pad_edges(data, padding, mode, **pad_kwargs), kernel, mode='valid'
     )
     return convolution
+
+
+def _safe_std(array, **kwargs):
+    """
+    Calculates the standard deviation and protects against nan and 0.
+
+    Used to prevent propogating nan or dividing by 0.
+
+    Parameters
+    ----------
+    array : numpy.ndarray
+        The array of values for calculating the standard deviation.
+    **kwargs
+        Additional keyword arguments to pass to :func:`numpy.std`.
+
+    Returns
+    -------
+    std : float
+        The standard deviation of the array, or `_MIN_FLOAT` if the
+        calculated standard deviation was 0 or if `array` was empty.
+
+    Notes
+    -----
+    Does not protect against the calculated standard deviation of a non-empty
+    array being nan because that would indicate that nan or inf was within the
+    array, which should not be protected.
+
+    """
+    if array.size < 2:  # std would be 0 for an array with size of 1
+        std = _MIN_FLOAT
+    else:
+        std = np.std(array, **kwargs)
+        if std == 0:
+            std = _MIN_FLOAT
+
+    return std

--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -1,4 +1,4 @@
 pillow==7.2.0
 sphinx==3.1.2
 sphinx-rtd-theme==0.4.3
-sphinx-autoapi==1.5.0
+sphinx-autoapi==1.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,10 @@ install_requires =
     scipy>=0.11
 zip_safe = False
 
+[options.extras_require]
+full = 
+    pentapy>=1.0
+
 [options.packages.find]
 include = pybaselines, pybaselines.*
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,16 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 import pytest
 
 
+try:
+    import pentapy  # noqa
+except ImportError:
+    no_pentapy = pytest.mark.skipif(False, reason='pentapy is not installed')
+    has_pentapy = pytest.mark.skipif(True, reason='pentapy is not installed')
+else:
+    no_pentapy = pytest.mark.skipif(True, reason='pentapy is installed')
+    has_pentapy = pytest.mark.skipif(False, reason='pentapy is installed')
+
+
 def gaussian(x, height=1.0, center=0.0, sigma=1.0):
     """
     Generates a gaussian distribution based on height, center, and sigma.

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -113,7 +113,7 @@ def test_setup_whittacker_y_array(small_data, array_enum):
 @pytest.mark.parametrize('lam', (1, 20))
 def test_setup_whittacker_diff_matrix(small_data, lam, diff_order):
     """Ensures output difference matrix is lam * diff_matrix.T * diff_matrix."""
-    _, diff_matrix, *_ = _algorithm_setup._setup_whittaker(small_data, lam, diff_order)
+    _, diff_matrix, _ = _algorithm_setup._setup_whittaker(small_data, lam, diff_order)
 
     # numpy gives transpose of the desired differential matrix
     numpy_diff = np.diff(np.eye(small_data.shape[0]), diff_order).T
@@ -124,7 +124,7 @@ def test_setup_whittacker_diff_matrix(small_data, lam, diff_order):
 
 @pytest.mark.parametrize('weight_enum', (0, 1, 2, 3))
 def test_setup_whittacker_weights(small_data, weight_enum):
-    """Ensures output weight matrix and array are correct."""
+    """Ensures output weight array is correct."""
     if weight_enum == 0:
         # no weights specified
         weights = None
@@ -142,11 +142,10 @@ def test_setup_whittacker_weights(small_data, weight_enum):
         weights = np.arange(small_data.shape[0]).tolist()
         desired_weights = np.arange(small_data.shape[0])
 
-    _, _, weight_matrix, weight_array = _algorithm_setup._setup_whittaker(small_data, 1, 2, weights)
+    _, _, weight_array = _algorithm_setup._setup_whittaker(small_data, 1, 2, weights)
 
     assert isinstance(weight_array, np.ndarray)
     assert_array_equal(weight_array, desired_weights)
-    assert_array_equal(weight_matrix.toarray(), np.diag(desired_weights))
 
 
 @pytest.mark.parametrize('diff_order', (0, -1))

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -9,7 +9,7 @@ Created on March 20, 2021
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 import pytest
-from scipy.sparse import identity
+from scipy.sparse import dia_matrix, identity
 
 from pybaselines import _algorithm_setup
 
@@ -64,11 +64,12 @@ def test_difference_matrix_order_neg():
 
 def test_difference_matrix_order_over():
     """
-    Tests the (n + 1)th order differential matrix against the actual
-    representation, where n is the number of data points.
+    Tests the (n + 1)th order differential matrix against the actual representation.
 
-    The differential matrix should be one of shape (0, n) with 0 stored elements,
+    If n is the number of data points and the difference order is greater than n,
+    then differential matrix should have a shape of (0, n) with 0 stored elements,
     following a similar logic as np.diff.
+
     """
     diff_matrix = _algorithm_setup.difference_matrix(10, 11).toarray()
     actual_matrix = np.empty(shape=(0, 10))
@@ -93,6 +94,36 @@ def test_difference_matrix_formats(form):
     assert _algorithm_setup.difference_matrix(10, 0, form).format == form
 
 
+@pytest.mark.parametrize('data_size', (10, 1001))
+@pytest.mark.parametrize('upper_only', (True, False))
+def test_diff_2_diags(data_size, upper_only):
+    """Ensures the output of _diff_2_diags is the correct shape and values."""
+    diagonal_data = _algorithm_setup._diff_2_diags(data_size, upper_only)
+
+    diff_matrix = _algorithm_setup.difference_matrix(data_size, 2)
+    diag_matrix = (diff_matrix.T * diff_matrix).todia()
+    actual_diagonal_data = diag_matrix.data
+    if upper_only:
+        actual_diagonal_data = diag_matrix.data[2:]
+
+    assert_array_equal(diagonal_data, actual_diagonal_data[::-1])
+
+
+@pytest.mark.parametrize('data_size', (10, 1001))
+@pytest.mark.parametrize('upper_only', (True, False))
+def test_diff_1_diags(data_size, upper_only):
+    """Ensures the output of _diff_1_diags is the correct shape and values."""
+    diagonal_data = _algorithm_setup._diff_1_diags(data_size, upper_only)
+
+    diff_matrix = _algorithm_setup.difference_matrix(data_size, 1)
+    diag_matrix = (diff_matrix.T * diff_matrix).todia()
+    actual_diagonal_data = diag_matrix.data
+    if upper_only:
+        actual_diagonal_data = diag_matrix.data[1:]
+
+    assert_array_equal(diagonal_data, actual_diagonal_data[::-1])
+
+
 @pytest.fixture
 def small_data():
     """A small array of data for testing."""
@@ -111,15 +142,20 @@ def test_setup_whittaker_y_array(small_data, array_enum):
 
 @pytest.mark.parametrize('diff_order', (1, 2))
 @pytest.mark.parametrize('lam', (1, 20))
-def test_setup_whittaker_diff_matrix(small_data, lam, diff_order):
-    """Ensures output difference matrix is lam * diff_matrix.T * diff_matrix."""
-    _, diff_matrix, _ = _algorithm_setup._setup_whittaker(small_data, lam, diff_order)
+@pytest.mark.parametrize('upper_only', (True, False))
+def test_setup_whittaker_diff_matrix(small_data, lam, diff_order, upper_only):
+    """Ensures output difference matrix diagonal data is in desired format."""
+    _, diagonal_data, _ = _algorithm_setup._setup_whittaker(
+        small_data, lam, diff_order, upper_only=upper_only
+    )
 
     # numpy gives transpose of the desired differential matrix
     numpy_diff = np.diff(np.eye(small_data.shape[0]), diff_order).T
-    desired_diff_matrix = lam * np.dot(numpy_diff.T, numpy_diff)
+    desired_diagonals = dia_matrix(lam * np.dot(numpy_diff.T, numpy_diff)).data
+    if upper_only:  # only include the upper diagonals
+        desired_diagonals = desired_diagonals[diff_order:]
 
-    assert_array_almost_equal(diff_matrix.toarray(), desired_diff_matrix)
+    assert_array_almost_equal(diagonal_data, desired_diagonals[::-1])
 
 
 @pytest.mark.parametrize('weight_enum', (0, 1, 2, 3))

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -76,6 +76,23 @@ def test_difference_matrix_order_over():
     assert_array_equal(diff_matrix, actual_matrix)
 
 
+def test_difference_matrix_size_neg():
+    """Ensures differential matrix fails for negative data size."""
+    with pytest.raises(ValueError):
+        _algorithm_setup.difference_matrix(-1)
+
+
+@pytest.mark.parametrize('form', ('dia', 'csc', 'csr'))
+def test_difference_matrix_formats(form):
+    """
+    Ensures that the sparse format is correctly passed to the constructor.
+
+    Tests both 0-order and 2-order, since 0-order uses a different constructor.
+    """
+    assert _algorithm_setup.difference_matrix(10, 2, form).format == form
+    assert _algorithm_setup.difference_matrix(10, 0, form).format == form
+
+
 @pytest.fixture
 def small_data():
     """A small array of data for testing."""

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -96,11 +96,11 @@ def test_difference_matrix_formats(form):
 @pytest.fixture
 def small_data():
     """A small array of data for testing."""
-    return np.arange(10)
+    return np.arange(10, dtype=float)
 
 
 @pytest.mark.parametrize('array_enum', (0, 1))
-def test_setup_whittacker_y_array(small_data, array_enum):
+def test_setup_whittaker_y_array(small_data, array_enum):
     """Ensures output y is always a numpy array."""
     if array_enum == 1:
         small_data = small_data.tolist()
@@ -111,7 +111,7 @@ def test_setup_whittacker_y_array(small_data, array_enum):
 
 @pytest.mark.parametrize('diff_order', (1, 2))
 @pytest.mark.parametrize('lam', (1, 20))
-def test_setup_whittacker_diff_matrix(small_data, lam, diff_order):
+def test_setup_whittaker_diff_matrix(small_data, lam, diff_order):
     """Ensures output difference matrix is lam * diff_matrix.T * diff_matrix."""
     _, diff_matrix, _ = _algorithm_setup._setup_whittaker(small_data, lam, diff_order)
 
@@ -123,7 +123,7 @@ def test_setup_whittacker_diff_matrix(small_data, lam, diff_order):
 
 
 @pytest.mark.parametrize('weight_enum', (0, 1, 2, 3))
-def test_setup_whittacker_weights(small_data, weight_enum):
+def test_setup_whittaker_weights(small_data, weight_enum):
     """Ensures output weight array is correct."""
     if weight_enum == 0:
         # no weights specified
@@ -148,15 +148,30 @@ def test_setup_whittacker_weights(small_data, weight_enum):
     assert_array_equal(weight_array, desired_weights)
 
 
+@pytest.mark.parametrize('filler', (np.nan, np.inf, -np.inf))
+def test_setup_whittaker_nan_inf_data_fails(small_data, filler):
+    """Ensures NaN and Inf values within data will raise an exception."""
+    small_data[0] = filler
+    with pytest.raises(ValueError):
+        _algorithm_setup._setup_whittaker(small_data, 1)
+
+
+def test_setup_whittaker_wrong_weight_shape(small_data):
+    """Ensures that an exception is raised if input weights and data are different shapes."""
+    weights = np.ones(small_data.shape[0] + 1)
+    with pytest.raises(ValueError):
+        _algorithm_setup._setup_whittaker(small_data, 1, 2, weights)
+
+
 @pytest.mark.parametrize('diff_order', (0, -1))
-def test_setup_whittacker_diff_matrix_fails(small_data, diff_order):
+def test_setup_whittaker_diff_matrix_fails(small_data, diff_order):
     """Ensures using a diff_order < 1 with _setup_whittaker raises an exception."""
     with pytest.raises(ValueError):
         _algorithm_setup._setup_whittaker(small_data, 1, diff_order)
 
 
 @pytest.mark.parametrize('diff_order', (4, 5))
-def test_setup_whittacker_diff_matrix_warns(small_data, diff_order):
+def test_setup_whittaker_diff_matrix_warns(small_data, diff_order):
     """Ensures using a diff_order > 3 with _setup_whittaker raises a warning."""
     with pytest.warns(UserWarning):
         _algorithm_setup._setup_whittaker(small_data, 1, diff_order)

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -140,13 +140,14 @@ def test_setup_whittaker_y_array(small_data, array_enum):
     assert isinstance(y, np.ndarray)
 
 
-@pytest.mark.parametrize('diff_order', (1, 2))
+@pytest.mark.parametrize('diff_order', (1, 2, 3))
 @pytest.mark.parametrize('lam', (1, 20))
 @pytest.mark.parametrize('upper_only', (True, False))
-def test_setup_whittaker_diff_matrix(small_data, lam, diff_order, upper_only):
+@pytest.mark.parametrize('reverse_diags', (True, False))
+def test_setup_whittaker_diff_matrix(small_data, lam, diff_order, upper_only, reverse_diags):
     """Ensures output difference matrix diagonal data is in desired format."""
     _, diagonal_data, _ = _algorithm_setup._setup_whittaker(
-        small_data, lam, diff_order, upper_only=upper_only
+        small_data, lam, diff_order, upper_only=upper_only, reverse_diags=reverse_diags
     )
 
     # numpy gives transpose of the desired differential matrix
@@ -155,7 +156,12 @@ def test_setup_whittaker_diff_matrix(small_data, lam, diff_order, upper_only):
     if upper_only:  # only include the upper diagonals
         desired_diagonals = desired_diagonals[diff_order:]
 
-    assert_array_almost_equal(diagonal_data, desired_diagonals[::-1])
+    # the diagonals should be in the opposite order as the diagonal matrix's data
+    # if reverse_diags is False
+    if not reverse_diags:
+        desired_diagonals = desired_diagonals[::-1]
+
+    assert_array_almost_equal(diagonal_data, desired_diagonals)
 
 
 @pytest.mark.parametrize('weight_enum', (0, 1, 2, 3))

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -111,6 +111,9 @@ class TestOptimizeExtendedRange(AlgorithmTester):
         if method == 'loess':
             # reduce number of calculations for loess since it is much slower
             kwargs = {'min_value': 1, 'max_value': 2}
+        elif 'poly' not in method:
+            # speed up whittaker tests
+            kwargs = {'min_value': 4}
         else:
             kwargs = {}
         # use height_scale=0.1 to avoid exponential overflow warning for arpls and aspls

--- a/tests/test_whittaker.py
+++ b/tests/test_whittaker.py
@@ -6,6 +6,7 @@ Created on March 20, 2021
 
 """
 
+import numpy as np
 import pytest
 
 from pybaselines import whittaker
@@ -145,6 +146,12 @@ class TestAsPLS(AlgorithmTester):
     def test_list_input(self):
         y_list = self.y.tolist()
         super()._test_algorithm_list(array_args=(self.y,), list_args=(y_list,))
+
+    def test_wrong_alpha_shape(self):
+        """Ensures that an exception is raised if input alpha and data are different shapes."""
+        alpha = np.ones(self.y.shape[0] + 1)
+        with pytest.raises(ValueError):
+            self._call_func(self.y, alpha=alpha)
 
 
 class TestPsalsa(AlgorithmTester):

--- a/tests/test_whittaker.py
+++ b/tests/test_whittaker.py
@@ -6,6 +6,8 @@ Created on March 20, 2021
 
 """
 
+import pytest
+
 from pybaselines import whittaker
 
 from .conftest import AlgorithmTester, get_data
@@ -27,6 +29,12 @@ class TestAsLS(AlgorithmTester):
         y_list = self.y.tolist()
         super()._test_algorithm_list(array_args=(self.y,), list_args=(y_list,))
 
+    @pytest.mark.parametrize('p', (-1, 2))
+    def test_outside_p_fails(self, p):
+        """Ensures p values outside of [0, 1] raise an exception."""
+        with pytest.raises(ValueError):
+            self._call_func(self.y, p=p)
+
 
 class TestIAsLS(AlgorithmTester):
     """Class for testing iasls baseline."""
@@ -46,6 +54,12 @@ class TestIAsLS(AlgorithmTester):
     def test_list_input(self):
         y_list = self.y.tolist()
         super()._test_algorithm_list(array_args=(self.y,), list_args=(y_list,))
+
+    @pytest.mark.parametrize('p', (-1, 2))
+    def test_outside_p_fails(self, p):
+        """Ensures p values outside of [0, 1] raise an exception."""
+        with pytest.raises(ValueError):
+            self._call_func(self.y, p=p)
 
 
 class TestAirPLS(AlgorithmTester):
@@ -148,3 +162,9 @@ class TestPsalsa(AlgorithmTester):
     def test_list_input(self):
         y_list = self.y.tolist()
         super()._test_algorithm_list(array_args=(self.y,), list_args=(y_list,))
+
+    @pytest.mark.parametrize('p', (-1, 2))
+    def test_outside_p_fails(self, p):
+        """Ensures p values outside of [0, 1] raise an exception."""
+        with pytest.raises(ValueError):
+            self._call_func(self.y, p=p)


### PR DESCRIPTION
<!--Please fill out all sections of the pull request template.-->

### Description
<!--Describe the pull request in detail, telling why the changes
are required and/or what problems they fix. Link or add the issue number
for any existing issues that the pull request solves.

Note that unsolicited pull requests will most likely be closed.
Please file an issue first, so that details can be discussed/finalized
before a pull request is created.-->
Switched to using banded solvers for all Whittaker methods, which reduced the computation time by ~60-85% compared to version 0.4.0 due to no longer having to create and modify large sparse matrices and using the faster solve(h)_banded functions. 

Added pentapy as an optional dependency. When pentapy is installed and the diff_order is 2 (pentadiagonal system), will use pentapy's solver, which is ~30-70% faster than SciPy's solve(h)_banded (~30-45% faster for tested datasets with 1000 points, ~45-70% faster for tested datasets with 10000 points), resulting in a total time reduction of 80-95% compared to v0.4.0.

Made the weight calculations for some Whittaker functions more robust by preventing nan values from being created.

### Type of Pull Request
<!--Put an x in all boxes that apply, like so: - [x] Bug Fix-->

- [x] Bug Fix
- [x] New Feature
- [x] Miscellaneous Changes (refactor, code improvements, etc.)
- [x] Documentation or Example Programs

### Pull Request Checklist
<!--Fill in all boxes with an x to verify.

To build documentation locally, type the following command within the
docs directory: make html
-->

- [x] New code and/or documentation is unique (not copied from elsewhere), and
      valid for use with the BSD 3-clause license.
- [x] New code is fully documented with docstrings that follow Numpy style,
      if applicable.
- [x] New code follows PEP 8 standards as closely as possible, if applicable.
- [x] Added/updated tests, if applicable.
- [x] Verified that documentation builds locally, if applicable.
