### PR TITLE
FEAT: Speed up penalized spline functions

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -3,7 +3,7 @@ licensed sources, which are listed below.
 
 
 Source: ported MATLAB code from https://www.mathworks.com/matlabcentral/fileexchange/27429-background-correction
-(accessed March 18, 2021)
+(last accessed March 18, 2021)
 Function: pybaselines.polynomial.penalized_poly
 License: 2-clause BSD
 
@@ -33,7 +33,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 
-Source: https://gist.github.com/agramfort/850437 (accessed March 25, 2021)
+Source: https://gist.github.com/agramfort/850437 (last accessed March 25, 2021)
 Function: pybaselines.polynomial.loess and all related functions
 License: 3-clause BSD
 
@@ -71,7 +71,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Source: ported MATLAB code from
 https://www.mathworks.com/matlabcentral/fileexchange/49974-beads-baseline-estimation-and-denoising-with-sparsity
-(accessed June 28, 2021)
+(last accessed June 28, 2021)
 Function: pybaselines.misc.beads and all related functions
 License: 3-clause BSD
 
@@ -101,7 +101,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-Source: bandmat (https://github.com/MattShannon/bandmat) (accessed July 10, 2021)
+Source: bandmat (https://github.com/MattShannon/bandmat, last accessed July 10, 2021)
 Function: pybaselines.misc._banded_dot_banded
 License: 3-clause BSD
 
@@ -160,3 +160,39 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+
+
+Source: SciPy (https://github.com/scipy/scipy, last accessed November 6, 2021)
+File: pybaselines._splines.py
+License: 3-clause BSD
+
+Copyright (c) 2001-2002 Enthought, Inc.  2003-2019, SciPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pybaselines/_algorithm_setup.py
+++ b/pybaselines/_algorithm_setup.py
@@ -20,7 +20,7 @@ from scipy.interpolate import splev
 from scipy.linalg import solveh_banded
 from scipy.sparse import csr_matrix
 
-from ._compat import _HAS_PENTAPY, _pentapy_solve
+from ._compat import _HAS_PENTAPY
 from .utils import (
     _check_scalar, _pentapy_solver, ParameterWarning, difference_matrix, optimize_window, pad_edges
 )
@@ -774,7 +774,7 @@ def _whittaker_smooth(data, lam=1e6, diff_order=2, weights=None):
     main_diag_idx = diff_order if using_pentapy else -1
     diagonals[main_diag_idx] = diagonals[main_diag_idx] + weight_array
     if using_pentapy:
-        smooth_y = _pentapy_solve(diagonals, weight_array * y, True, True, _pentapy_solver())
+        smooth_y = _pentapy_solver(diagonals, weight_array * y)
     else:
         smooth_y = solveh_banded(
             diagonals, weight_array * y, overwrite_ab=True, overwrite_b=True, check_finite=False

--- a/pybaselines/_spline_utils.py
+++ b/pybaselines/_spline_utils.py
@@ -1,0 +1,575 @@
+# -*- coding: utf-8 -*-
+"""Helper functions for using splines.
+
+Created on November 3, 2021
+@author: Donald Erb
+
+
+Several functions were adapted from Cython, Python, and C files from SciPy
+(https://github.com/scipy/scipy, accessed November 2, 2021), which was
+licensed under the BSD-3-Clause below.
+
+Copyright (c) 2001-2002 Enthought, Inc.  2003-2019, SciPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+import numpy as np
+from scipy.interpolate import BSpline, splev
+from scipy.linalg import solveh_banded
+from scipy.sparse import csc_matrix, csr_matrix, spdiags
+
+from ._compat import _HAS_NUMBA, jit
+
+try:
+    from scipy.interpolate import _bspl
+    _scipy_btb_bty = _bspl._norm_eq_lsq
+except (AttributeError, ImportError):
+    # in case scipy ever changes
+    _scipy_btb_bty = None
+
+
+# adapted from scipy (scipy/interpolate/_bspl.pyx/find_interval); see license above
+@jit(nopython=True, cache=True)
+def _find_interval(knots, spline_degree, x_val, last_left, num_bases):
+    """
+    Finds the knot interval containing the x-value.
+
+    Parameters
+    ----------
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    spline_degree : int
+        The spline degree.
+    x_val : float
+        The x-value to find the interval for.
+    last_left : int
+        The previous output of this function. For the first call, use any value
+        less than `spline_degree` to start.
+    num_bases : int
+        The total number of basis functions. Equals ``len(knots) - spline_degree - 1``,
+        but is precomputed rather than having to recompute each function call.
+
+    Returns
+    -------
+    int
+        The index in `knots` such that ``knots[index] <= x_val < knots[index + 1]``.
+
+    """
+    left = last_left if spline_degree < last_left < num_bases else spline_degree
+
+    # x_val less than expected so shift knot interval left
+    while x_val < knots[left] and left != spline_degree:
+        left -= 1
+
+    left += 1
+    while x_val >= knots[left] and left != num_bases:
+        left += 1
+
+    return left - 1
+
+
+# adapted from scipy (scipy/interpolate/src/__fitpack.h/_deBoor_D); see license above
+@jit(nopython=True, cache=True)
+def _de_boor(knots, x_val, spline_degree, left_knot_idx, work):
+    """
+    Computes the non-zero values of the spline bases for the given x-value.
+
+    Parameters
+    ----------
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    x_val : float
+        The x-value at which the spline basis is being computed.
+    spline_degree : int
+        The degree of the spline.
+    left_knot_idx : int
+        The index in `knots` that defines the interval such that
+        ``knots[left_knot_idx] <= x_val < knots[left_knot_idx + 1]``.
+    work : numpy.ndarray, shape (``2 * (spline_degree + 1)``,)
+        The working array. Modified inplace to store the non-zero values of the spline
+        bases for `x_val`.
+
+    Notes
+    -----
+    Computes the non-zero values for knots from ``knots[left_knot_idx]`` to
+    ``knots[left_knot_idx - spline_degree]`` for the x-value using de Boor's recursive
+    algorithm.
+
+    """
+    temp = work + spline_degree + 1
+    work[0] = 1.0
+    for i in range(1, spline_degree + 1):
+        temp[:i] = work[:i]
+        work[0] = 0.0
+        for j in range(1, i + 1):
+            idx = left_knot_idx + j
+            right_knot = knots[idx]
+            left_knot = knots[idx - i]
+            if left_knot == right_knot:
+                work[j] = 0.0
+                continue
+
+            factor = temp[j - 1] / (right_knot - left_knot)
+            work[j - 1] += factor * (right_knot - x_val)
+            work[j] = factor * (x_val - left_knot)
+
+
+# adapted from scipy (scipy/interpolate/_bspl.pyx/_make_design_matrix); see license above
+@jit(nopython=True, cache=True)
+def __make_design_matrix(x, knots, spline_degree):
+    """
+    Calculates the data needed to create the sparse matrix of basis functions for the spline.
+
+    Parameters
+    ----------
+    x : numpy.ndarray, shape (N,)
+        The x-values for the spline.
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    spline_degree : int
+        The degree of the spline.
+
+    Returns
+    -------
+    basis_data : numpy.ndarray, shape (``N * (spline_degree + 1)``,)
+        The data for all of the basis functions. The basis for each `x[i]` value is represented
+        by ``basis_data[i * (spline_degree + 1):(i + 1) * (spline_degree + 1)]``.
+    row_ind : numpy.ndarray, shape (``N * (spline_degree + 1)``,)
+        The row indices of the data; used for converting `data` into a CSR matrix.
+    col_ind : numpy.ndarray, shape (``N * (spline_degree + 1)``,)
+        The column indices of the data; used for converting `data` into a CSR matrix.
+
+    """
+    len_x = len(x)
+    spline_order = spline_degree + 1
+    data_length = len_x * spline_order
+    num_bases = len(knots) - spline_order
+    work = np.zeros(2 * spline_order)
+    basis_data = np.zeros(data_length)
+    row_ind = np.zeros(data_length, dtype=np.intp)
+    col_ind = np.zeros(data_length, dtype=np.intp)
+
+    idx = 0
+    left_knot_idx = spline_degree
+    for i in range(len_x):
+        x_val = x[i]
+        left_knot_idx = _find_interval(knots, spline_degree, x_val, left_knot_idx, num_bases)
+        _de_boor(knots, x_val, spline_degree, left_knot_idx, work)
+
+        next_idx = idx + spline_order
+        basis_data[idx:next_idx] = work[:spline_order]
+        row_ind[idx:next_idx] = i
+        col_ind[idx:next_idx] = np.arange(
+            left_knot_idx - spline_degree, min(left_knot_idx + 1, num_bases)
+        )
+        idx = next_idx
+
+    return basis_data, row_ind, col_ind
+
+
+# adapted from scipy (scipy/interpolate/_bspl.pyx/_make_design_matrix); see license above
+def _make_design_matrix(x, knots, spline_degree):
+    """
+    Creates the sparse matrix of basis functions for a B-spline.
+
+    Parameters
+    ----------
+    x : numpy.ndarray, shape (N,)
+        The x-values for the spline.
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    spline_degree : int
+        The degree of the spline.
+
+    Returns
+    -------
+    scipy.sparse.csr.csr_matrix, shape (N, K - `spline_degree` - 1)
+        The sparse matrix containing all the spline basis functions.
+
+    """
+    data, row_ind, col_ind = __make_design_matrix(x, knots, spline_degree)
+    return csr_matrix((data, (row_ind, col_ind)), (len(x), len(knots) - spline_degree - 1))
+
+
+def _slow_design_matrix(x, knots, spline_degree):
+    """
+    A nieve way of constructing the B-spline basis matrix by evaluating each basis individually.
+
+    Parameters
+    ----------
+    x : numpy.ndarray, shape (N,)
+        The x-values for the spline.
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    spline_degree : int
+        The degree of the spline.
+
+    Returns
+    -------
+    scipy.sparse.csr.csr_matrix, shape (N, K - `spline_degree` - 1)
+        The sparse matrix containing all the spline basis functions.
+
+    """
+    num_bases = len(knots) - spline_degree - 1
+    basis = np.empty((num_bases, len(x)))
+    coeffs = np.zeros(num_bases)
+    # TODO this is still quite slow and memory intensive; could make something similar
+    # to __make_design_matrix that is still fast enough without numba; could make a cached
+    # version, but would need to be able to use knots and x without cacheing them since numpy
+    # arrays are not hashable -> use an inner function probably; also has the benefit that
+    # cache gets automatically deleted once basis is created; a cached version would probably
+    # also be faster than the current numba version of _deBoor (assuming numba allows inner
+    # functions and dictionaries/caches?)
+
+    # evaluate each single basis
+    for i in range(num_bases):
+        coeffs[i] = 1  # evaluate the i-th basis within splev
+        basis[i] = splev(x, (knots, coeffs, spline_degree))
+        coeffs[i] = 0  # reset back to zero
+
+    # The last and first coefficients for the first and last bases, respectively,
+    # get values == 0 when doing the above calculation, which causes issues when
+    # using the resulting csr_matrix's data attribute; instead, explicitly set
+    # those values to a very small, non-zero value; if spline_degree==0, it's fine
+    if spline_degree > 0:
+        small_float = np.finfo(float).tiny
+        basis[spline_degree, 0] = small_float
+        basis[-(spline_degree + 1), -1] = small_float
+
+    return csc_matrix(basis).T
+
+
+def _spline_knots(x, num_knots=10, spline_degree=3, penalized=False):
+    """
+    Creates the basis matrix for B-splines and P-splines.
+
+    Parameters
+    ----------
+    x : numpy.ndarray, shape (N,)
+        The array of x-values
+    num_knots : int, optional
+        The number of interior knots for the spline. Default is 10.
+    spline_degree : int, optional
+        The degree of the spline. Default is 3, which is a cubic spline.
+    penalized : bool, optional
+        Whether the basis matrix should be for a penalized spline or a regular
+        B-spline. Default is False, which creates the basis for a B-spline.
+
+    Returns
+    -------
+    knots : numpy.ndarray, shape (``num_knots + 2 * spline_degree``,)
+        The array of knots for the spline, properly padded on each side.
+
+    Notes
+    -----
+    If `penalized` is True, makes the knots uniformly spaced to create penalized
+    B-splines (P-splines). That way, can use a finite difference matrix to impose
+    penalties on the spline.
+
+    The knots are padded on each end with `spline_degree` extra knots to provide proper
+    support for the outermost inner knots.
+
+    References
+    ----------
+    Eilers, P., et al. Twenty years of P-splines. SORT: Statistics and Operations Research
+    Transactions, 2015, 39(2), 149-186.
+
+    Hastie, T., et al. The Elements of Statistical Learning. Springer, 2017. Chapter 5.
+
+    """
+    if penalized:
+        x_min = x.min()
+        x_max = x.max()
+        # number of sections is num_knots - 1 since counting the first and last
+        # knots as inner knots
+        dx = (x_max - x_min) / (num_knots - 1)
+        # calculate inner knots separately to ensure x_min and x_max are correct;
+        # otherwise, they can be slighly off due to floating point errors
+        inner_knots = np.linspace(x_min, x_max, num_knots)
+        knots = np.concatenate((
+            np.linspace(x_min - spline_degree * dx, x_min - dx, spline_degree),
+            inner_knots,
+            np.linspace(x_max + dx, x_max + spline_degree * dx, spline_degree),
+        ))
+    else:
+        # TODO maybe provide a better way to select knot positions for regular B-splines
+        inner_knots = np.percentile(x, np.linspace(0, 100, num_knots))
+        knots = np.concatenate((
+            np.repeat(inner_knots[0], spline_degree), inner_knots,
+            np.repeat(inner_knots[-1], spline_degree)
+        ))
+
+    return knots
+
+
+def _spline_basis(x, knots, spline_degree=3):
+    """
+    Constructs the spline basis matrix.
+
+    Chooses the fastest constuction route based on the available options.
+
+    Parameters
+    ----------
+    x : numpy.ndarray, shape (N,)
+        The x-values for the spline.
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    spline_degree : int, optional
+        The degree of the spline. Default is 3, which is a cubic spline.
+
+    Returns
+    -------
+    numpy.ndarray, shape (N, K - `spline_degree` - 1)
+        The matrix of basis functions for the spline.
+
+    Notes
+    -----
+    The numba version is ~70% faster than scipy's BSpline.design_matrix (tested
+    with python 3.9.7 and scipy 1.8.0.dev0+1981), so the numba version is preferred.
+
+    Most checks on the inputs are skipped since this is an internal function and the
+    proper steps are assumed to be done. For more proper error handling in the inputs,
+    see :func:`scipy.interpolate.make_lsq_spline`.
+
+    """
+    if _HAS_NUMBA:
+        validate_inputs = True
+        basis_func = _make_design_matrix
+    elif hasattr(BSpline, 'design_matrix'):
+        validate_inputs = False
+        # BSpline.design_matrix introduced in scipy version 1.8.0
+        basis_func = BSpline.design_matrix
+    else:
+        validate_inputs = True
+        basis_func = _slow_design_matrix
+
+    # validate inputs only if not using scipy's version
+    if validate_inputs:
+        len_knots = len(knots)
+        if np.any(x < knots[spline_degree]) or np.any(x > knots[len_knots - spline_degree - 1]):
+            raise ValueError((
+                f'x-values are either < {knots[spline_degree]} or '
+                f'> {knots[len_knots - spline_degree - 1]}'
+            ))
+
+    return basis_func(x, knots, spline_degree)
+
+
+# adapted from scipy (scipy/interpolate/_bspl.pyx/_norm_eq_lsq); see license above
+@jit(nopython=True, cache=True)
+def _numba_btb_bty(x, knots, spline_degree, y, weights, ab, rhs, basis_data):
+    """
+    Computes ``B.T @ W @ B`` and ``B.T @ W @ y`` for a spline.
+
+    The result of ``B.T @ W @ B`` is stored in LAPACK's lower banded format (see
+    :func:`scipy.linalg.solveh_banded`).
+
+    Parameters
+    ----------
+    x : numpy.ndarray, shape (N,)
+        The x-values for the spline.
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    spline_degree : int
+        The degree of the spline.
+    y : numpy.ndarray, shape (N,)
+        The y-values for fitting the spline.
+    weights : numpy.ndarray, shape(N,)
+        The weights for each y-value.
+    ab : numpy.ndarray, shape (`spline_degree` + 1, N)
+        An array of zeros that will be modified inplace to contain ``B.T @ W @ B`` in
+        lower banded format.
+    rhs : numpy.ndarray, shape (N,)
+        An array of zeros that will be modified inplace to contain the right-hand
+        side of the normal equation, ``B.T @ W @ y``.
+    basis_data : numpy.ndarray, shape (``N * (spline_degree + 1)``,)
+        The data for all of the basis functions. The basis for each `x[i]` value is represented
+        by ``basis_data[i * (spline_degree + 1):(i + 1) * (spline_degree + 1)]``. If the basis,
+        `B` is a sparse matrix, then `basis_data` can be gotten using `B.tocsr().data`.
+
+    Notes
+    -----
+    This function is slightly different than SciPy's `_norm_eq_lst` function in
+    scipy.interpolate._bspl.pyx since this function uses the weights directly, rather
+    than squaring the weights, and directly uses the basis data (gotten by using the
+    `data` attribute of the basis in CSR sparse format) rather than computing the
+    basis using de Boor's algorithm. This makes it much faster when solving a spline
+    system using iteratively reweighted least squares since the basis only needs to be
+    created once.
+
+    There is no significant time difference between calling _find_interval each time this
+    function is used compared to calculating all the intervals once and inputting them
+    into this function.
+
+    """
+    spline_order = spline_degree + 1
+    num_bases = len(knots) - spline_order
+    work = np.zeros(2 * spline_order)
+
+    left_knot_idx = spline_degree
+    idx = 0
+    for i in range(len(x)):
+        x_val = x[i]
+        y_val = y[i]
+        weight_val = weights[i]
+        left_knot_idx = _find_interval(knots, spline_degree, x_val, left_knot_idx, num_bases)
+
+        next_idx = idx + spline_order
+        work[:] = 0
+        work[:spline_order] = basis_data[idx:next_idx]
+        idx = next_idx
+        for j in range(spline_order):
+            work_val = work[j]
+            # B.T @ W @ B
+            for k in range(j + 1):
+                column = left_knot_idx - spline_degree + k
+                ab[j - k, column] += work_val * work[k] * weight_val
+
+            # B.T @ W @ y
+            row = left_knot_idx - spline_degree + j
+            rhs[row] += work_val * y_val * weight_val
+
+
+# adapted from scipy (scipy/interpolate/_bsplines.py/make_lsq_spline); see license above
+def _solve_pspline(x, y, weights, basis, penalty, knots, spline_degree):
+    """
+    Solves the coefficients for a weighted penalized spline.
+
+    Solves the linear equation ``(B.T @ W @ B + P) c = B.T @ W @ y`` for the spline
+    coefficients, `c`, given the spline basis, `B`, the weights (diagonal of `W`), the
+    penalty `P`, and `y`. Attempts to calculate ``B.T @ W @ B`` and ``B.T @ W @ y`` as
+    a banded system to speed up the calculation.
+
+    Parameters
+    ----------
+    x : numpy.ndarray, shape (N,)
+        The x-values for the spline.
+    y : numpy.ndarray, shape (N,)
+        The y-values for fitting the spline.
+    weights : numpy.ndarray, shape (N,)
+        The weights for each y-value.
+    basis : scipy.sparse.base.spmatrix, shape (N, K - `spline_degree` - 1)
+        The sparse spline basis matrix. CSR format is preferred.
+    penalty : numpy.ndarray, shape (D, N)
+        The finite difference penalty matrix, in LAPACK's lower banded format (see
+        :func:`scipy.linalg.solveh_banded`).
+    knots : numpy.ndarray, shape (K,)
+        The array of knots for the spline. Should be padded on each end with
+        `spline_degree` extra knots.
+    spline_degree : int
+        The degree of the spline.
+
+    Returns
+    -------
+    coeffs : numpy.ndarray, shape (K - `spline_degree` - 1,)
+        The coefficients for the spline. To calculate the spline, do ``basis @ coeffs``.
+
+    Raises
+    ------
+    ValueError
+        Raised if `penalty` and the calculated `basis.T @ W @ basis` have different number
+        of columns.
+
+    Notes
+    -----
+    Most checks on the inputs are skipped since this is an internal function and the
+    proper steps are assumed to be done. For more proper error handling in the inputs,
+    see :func:`scipy.interpolate.make_lsq_spline`.
+
+    """
+    use_backup = True
+    num_bases = basis.shape[1]
+    # prefer numba version since it directly uses the basis
+    if _HAS_NUMBA:
+        # the spline basis must explicitly be created such that the csr matrix's data
+        # attribute is not missing any zeros; it is correct for all the internal basis
+        # creation functions used, but need to ensure just in case something ever changes;
+        # could guess if missing_values==2 that the first and last basis functions are
+        # missing a near-zero value, but safer to just move to other options
+        basis_data = basis.tocsr().data
+        missing_values = len(y) * (spline_degree + 1) - len(basis_data)
+        if not missing_values:
+            # TODO if using the numba version, does fortran ordering speed up the calc? or
+            # can ab just be c ordered?
+
+            # create ab and rhs arrays outside of numba function since numba's implementation
+            # of np.zeros is slower than numpy's (https://github.com/numba/numba/issues/7259)
+            ab = np.zeros((spline_degree + 1, num_bases), order='F')
+            rhs = np.zeros(num_bases)
+            _numba_btb_bty(x, knots, spline_degree, y, weights, ab, rhs, basis_data)
+            use_backup = False
+
+    if use_backup and _scipy_btb_bty is not None:
+        ab = np.zeros((spline_degree + 1, num_bases), order='F')
+        rhs = np.zeros((num_bases, 1), order='F')
+        _scipy_btb_bty(x, knots, spline_degree, y.reshape(-1, 1), np.sqrt(weights), ab, rhs)
+        rhs = rhs.reshape(-1)
+        use_backup = False
+    if use_backup:
+        # worst case scenario; have to convert weights to a sparse diagonal matrix,
+        # do B.T @ W @ B, and convert back to lower banded
+        len_y = len(y)
+        full_matrix = basis.T @ spdiags(weights, 0, len_y, len_y, 'csr') @ basis
+        ab = full_matrix.todia().data[::-1]
+        # take only the lower diagonals of the symmetric ab; cannot just do
+        # ab[spline_degree:] since some diagonals become fully 0 and are truncated from
+        # the data attribute, so have to calculate the number of bands first
+        ab = ab[len(ab) // 2:]
+        rhs = basis.T @ (weights * y)
+
+    ab_shape = ab.shape
+    penalty_shape = penalty.shape
+    if ab_shape[1] != penalty_shape[1]:
+        raise ValueError('penalty matrix and basis.T @ W @ basis have a dimension mismatch')
+    lhs_row_mismatch = ab_shape[0] - penalty_shape[0]
+    if lhs_row_mismatch == 0:
+        lhs = ab + penalty
+    else:
+        # TODO could probably just use indexing rather than padding
+        padding = np.zeros((abs(lhs_row_mismatch), penalty_shape[1]))
+        if lhs_row_mismatch > 0:
+            lhs = ab + np.concatenate((penalty, padding))
+        else:
+            lhs = np.concatenate((ab, padding)) + penalty
+
+    coeffs = solveh_banded(
+        lhs, rhs, overwrite_ab=True, overwrite_b=True, lower=True, check_finite=False
+    )
+
+    return coeffs

--- a/pybaselines/morphological.py
+++ b/pybaselines/morphological.py
@@ -15,7 +15,7 @@ from scipy.sparse.linalg import spsolve
 from ._algorithm_setup import (
     _check_lam, _setup_morphology, _setup_splines, _setup_whittaker, _whittaker_smooth
 )
-from ._compat import _HAS_PENTAPY, _pentapy_solve
+from ._compat import _HAS_PENTAPY
 from .utils import (
     _mollifier_kernel, _pentapy_solver, pad_edges, padded_convolve, relative_difference
 )
@@ -911,7 +911,6 @@ def jbcd(data, half_window=None, alpha=0.1, beta=1e1, gamma=1., beta_mult=1.1, g
     baseline_old = opening
     signal_old = y
     main_diag_idx = diff_order if using_pentapy else -1
-    pentapy_solver = _pentapy_solver()
     partial_rhs_2 = (2 * alpha) * opening
     tol_history = np.empty((max_iter + 1, 2))
     for i in range(max_iter + 1):
@@ -920,10 +919,8 @@ def jbcd(data, half_window=None, alpha=0.1, beta=1e1, gamma=1., beta_mult=1.1, g
         lhs_2 = (2 * beta) * penalty_diagonals
         lhs_2[main_diag_idx] += 1. + 2. * alpha
         if using_pentapy:
-            signal = _pentapy_solve(lhs_1, y - baseline_old, True, True, pentapy_solver)
-            baseline = _pentapy_solve(
-                lhs_2, y - signal + partial_rhs_2, True, True, pentapy_solver
-            )
+            signal = _pentapy_solver(lhs_1, y - baseline_old)
+            baseline = _pentapy_solver(lhs_2, y - signal + partial_rhs_2)
         else:
             signal = solveh_banded(
                 lhs_1, y - baseline_old, overwrite_ab=True, overwrite_b=True, check_finite=False

--- a/pybaselines/morphological.py
+++ b/pybaselines/morphological.py
@@ -769,7 +769,7 @@ def mpspline(data, half_window=None, lam=1e4, lam_smooth=1e-2, p=0.0, num_knots=
     elif not 0 <= p <= 1:
         raise ValueError('p must be between 0 and 1')
 
-    y, _, spl_basis, weight_array, penalty_matrix = _setup_splines(
+    y, _, weight_array, spl_basis, penalty_matrix = _setup_splines(
         data, None, weights, spline_degree, num_knots, True, diff_order, lam_smooth
     )
     # TODO should this use np.isclose instead?

--- a/pybaselines/polynomial.py
+++ b/pybaselines/polynomial.py
@@ -999,7 +999,7 @@ def _loess_nonfirst_loops(y, weights, coefs, vander, kernels, windows, num_x, fi
     return baseline
 
 
-@jit(nopython=True, cache=True, fastmath=True)
+@jit(nopython=True, cache=True)
 def _determine_fits(x, num_x, total_points, delta):
     """
     Determines the x-values to fit and the left and right indices for each fit x-value.

--- a/pybaselines/utils.py
+++ b/pybaselines/utils.py
@@ -592,7 +592,7 @@ def difference_matrix(data_size, diff_order=2, diff_format=None):
         np.diff(np.eye(data_size), diff_order, axis=0)
 
     This implementation allows using the differential matrices are they
-    are written in various publications, ie. D.T @ D.
+    are written in various publications, ie. ``D.T @ D``.
 
     Most baseline algorithms use 2nd order differential matrices when
     doing penalized least squared fitting or Whittaker-smoothing-based fitting.

--- a/pybaselines/utils.py
+++ b/pybaselines/utils.py
@@ -13,7 +13,7 @@ from scipy.ndimage import grey_opening
 from scipy.signal import convolve
 from scipy.sparse import diags, identity
 
-from ._compat import jit
+from ._compat import jit, _pentapy_solve
 
 
 # Note: the triple quotes are for including the attributes within the documentation
@@ -25,17 +25,28 @@ or 1. See :func:`pentapy.core.solve` for more details.
 """
 
 
-def _pentapy_solver():
+def _pentapy_solver(ab, y):
     """
-    Convenience function for getting the current pentapy solver.
+    Convenience function for calling pentapy's solver with defaults already set.
+
+    Solves the linear system :math:`A @ x = y` for `x`, given the matrix `A` in
+    banded format, `ab`. The default settings of :func`:pentapy.solve` are
+    already set for the fastest configuration.
+
+    Parameters
+    ----------
+    ab : array-like
+        The matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+    y : array-like
+        The right hand side of the equation.
 
     Returns
     -------
-    PENTAPY_SOLVER : str or int
-        The currently specified solver for pentapy.
+    numpy.ndarray
+        The solution to the linear system.
 
     """
-    return PENTAPY_SOLVER
+    return _pentapy_solve(ab, y, is_flat=True, index_row_wise=True, solver=PENTAPY_SOLVER)
 
 
 # the minimum positive float values such that a + _MIN_FLOAT != a

--- a/pybaselines/utils.py
+++ b/pybaselines/utils.py
@@ -586,13 +586,16 @@ def difference_matrix(data_size, diff_order=2, diff_format=None):
 
     Notes
     -----
+    The resulting matrices are sparse versions of::
+
+        import numpy as np
+        np.diff(np.eye(data_size), diff_order, axis=0)
+
+    This implementation allows using the differential matrices are they
+    are written in various publications, ie. D.T @ D.
+
     Most baseline algorithms use 2nd order differential matrices when
     doing penalized least squared fitting or Whittaker-smoothing-based fitting.
-
-    The resulting matrices are transposes of the result of
-    np.diff(np.eye(data_size), diff_order). This implementation allows using
-    the differential matrices are they are written in various publications,
-    ie. D.T * D.
 
     """
     if diff_order < 0:

--- a/pybaselines/whittaker.py
+++ b/pybaselines/whittaker.py
@@ -13,7 +13,7 @@ from scipy.linalg import solve_banded, solveh_banded
 from scipy.special import expit
 
 from ._algorithm_setup import _check_lam, _diff_1_diags, _setup_whittaker, _yx_arrays
-from ._compat import _HAS_PENTAPY, _pentapy_solve
+from ._compat import _HAS_PENTAPY
 from .utils import (
     ParameterWarning, _mollifier_kernel, _pentapy_solver, _safe_std, pad_edges,
     padded_convolve, relative_difference
@@ -134,7 +134,7 @@ def asls(data, lam=1e6, p=1e-2, diff_order=2, max_iter=50, tol=1e-3, weights=Non
     for i in range(max_iter + 1):
         diagonals[main_diag_idx] = main_diagonal + weight_array
         if using_pentapy:
-            baseline = _pentapy_solve(diagonals, weight_array * y, True, True, _pentapy_solver())
+            baseline = _pentapy_solver(diagonals, weight_array * y)
         else:
             baseline = solveh_banded(
                 diagonals, weight_array * y, overwrite_b=True, check_finite=False
@@ -243,9 +243,7 @@ def iasls(data, x_data=None, lam=1e6, p=1e-2, lam_1=1e-4, max_iter=50, tol=1e-3,
         weight_squared = weight_array * weight_array
         diagonals[main_diag_idx] = main_diagonal + weight_squared
         if _HAS_PENTAPY:
-            baseline = _pentapy_solve(
-                diagonals, weight_squared * y + d1_y, True, True, _pentapy_solver()
-            )
+            baseline = _pentapy_solver(diagonals, weight_squared * y + d1_y)
         else:
             baseline = solveh_banded(
                 diagonals, weight_squared * y + d1_y, overwrite_b=True, check_finite=False
@@ -322,9 +320,7 @@ def airpls(data, lam=1e6, diff_order=2, max_iter=50, tol=1e-3, weights=None):
     for i in range(1, max_iter + 2):
         diagonals[main_diag_idx] = main_diagonal + weight_array
         if using_pentapy:
-            output = _pentapy_solve(
-                diagonals, weight_array * y, True, True, _pentapy_solver()
-            )
+            output = _pentapy_solver(diagonals, weight_array * y)
             # if weights are all ~0, then pentapy sometimes outputs nan without
             # warnings or errors, so have to check
             if np.isfinite(output.dot(output)):
@@ -435,9 +431,7 @@ def arpls(data, lam=1e5, diff_order=2, max_iter=50, tol=1e-3, weights=None):
     for i in range(max_iter + 1):
         diagonals[main_diag_idx] = main_diagonal + weight_array
         if using_pentapy:
-            baseline = _pentapy_solve(
-                diagonals, weight_array * y, True, True, _pentapy_solver()
-            )
+            baseline = _pentapy_solver(diagonals, weight_array * y)
         else:
             baseline = solveh_banded(
                 diagonals, weight_array * y, overwrite_b=True, check_finite=False
@@ -515,8 +509,8 @@ def drpls(data, lam=1e5, eta=0.5, max_iter=50, tol=1e-3, weights=None):
     for i in range(1, max_iter + 2):
         d2_w_diagonals = d2_diagonals * weight_array
         if _HAS_PENTAPY:
-            baseline = _pentapy_solve(
-                d1_d2_diagonals + d2_w_diagonals, weight_array * y, True, True, _pentapy_solver()
+            baseline = _pentapy_solver(
+                d1_d2_diagonals + d2_w_diagonals, weight_array * y
             )
         else:
             baseline = solve_banded(
@@ -606,9 +600,7 @@ def iarpls(data, lam=1e5, diff_order=2, max_iter=50, tol=1e-3, weights=None):
     for i in range(1, max_iter + 2):
         diagonals[main_diag_idx] = main_diagonal + weight_array
         if using_pentapy:
-            baseline = _pentapy_solve(
-                diagonals, weight_array * y, True, True, _pentapy_solver()
-            )
+            baseline = _pentapy_solver(diagonals, weight_array * y)
         else:
             baseline = solveh_banded(
                 diagonals, weight_array * y, overwrite_b=True, check_finite=False
@@ -713,9 +705,7 @@ def aspls(data, lam=1e5, diff_order=2, max_iter=100, tol=1e-3, weights=None, alp
         alpha_diagonals = diagonals * alpha_array
         alpha_diagonals[diff_order] = alpha_diagonals[diff_order] + weight_array
         if using_pentapy:
-            baseline = _pentapy_solve(
-                alpha_diagonals, weight_array * y, True, True, _pentapy_solver()
-            )
+            baseline = _pentapy_solver(alpha_diagonals, weight_array * y)
         else:
             baseline = solve_banded(
                 lower_upper, _shift_rows(alpha_diagonals, diff_order), weight_array * y,
@@ -827,9 +817,7 @@ def psalsa(data, lam=1e5, p=0.5, k=None, diff_order=2, max_iter=50, tol=1e-3, we
     for i in range(max_iter + 1):
         diagonals[main_diag_idx] = main_diagonal + weight_array
         if using_pentapy:
-            baseline = _pentapy_solve(
-                diagonals, weight_array * y, True, True, _pentapy_solver()
-            )
+            baseline = _pentapy_solver(diagonals, weight_array * y)
         else:
             baseline = solveh_banded(
                 diagonals, weight_array * y, overwrite_b=True, check_finite=False
@@ -957,9 +945,7 @@ def derpsalsa(data, lam=1e6, p=0.01, k=None, diff_order=2, max_iter=50, tol=1e-3
     for i in range(max_iter + 1):
         diagonals[main_diag_idx] = main_diagonal + weight_array
         if using_pentapy:
-            baseline = _pentapy_solve(
-                diagonals, weight_array * y, True, True, _pentapy_solver()
-            )
+            baseline = _pentapy_solver(diagonals, weight_array * y)
         else:
             baseline = solveh_banded(
                 diagonals, weight_array * y, overwrite_b=True, check_finite=False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 """Tests for pybaselines."""

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -426,17 +426,6 @@ def test_setup_splines_array_lam(small_data):
         _algorithm_setup._setup_splines(small_data, lam=[1, 2])
 
 
-def test_changing_pentapy_solver():
-    """Ensure a change to utils.PENTAPY_SOLVER is communicated to pybaselines._algorithms_setup."""
-    original_solver = utils.PENTAPY_SOLVER
-    try:
-        for solver in range(5):
-            utils.PENTAPY_SOLVER = solver
-            assert _algorithm_setup._pentapy_solver() == solver
-    finally:
-        utils.PENTAPY_SOLVER = original_solver
-
-
 @pytest.mark.parametrize('lam', (5, [5], (5,), [[5]], np.array(5), np.array([5]), np.array([[5]])))
 def test_check_lam(lam):
     """Ensures scalar lam values are correctly processed."""

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -64,7 +64,8 @@ def test_rolling_std(y_scale, half_window, ddof):
 
     """
     x = np.arange(100)
-    y = y_scale * np.sin(x) + np.random.normal(0, 0.2, x.size)
+    # TODO replace with np.random.default_rng when min numpy version is >= 1.17
+    y = y_scale * np.sin(x) + np.random.RandomState(0).normal(0, 0.2, x.size)
     # only compare within [half_window:-half_window] since the calculation
     # can have slightly different values at the edges
     compare_slice = slice(half_window, -half_window)
@@ -90,7 +91,8 @@ def test_padded_rolling_std(y_scale, half_window, ddof):
 
     """
     x = np.arange(100)
-    y = y_scale * np.sin(x) + np.random.normal(0, 0.2, x.size)
+    # TODO replace with np.random.default_rng when min numpy version is >= 1.17
+    y = y_scale * np.sin(x) + np.random.RandomState(0).normal(0, 0.2, x.size)
     # only compare within [half_window:-half_window] since the calculation
     # can have slightly different values at the edges
     compare_slice = slice(half_window, -half_window)

--- a/tests/test_spline.py
+++ b/tests/test_spline.py
@@ -127,9 +127,11 @@ class TestMixtureModel(AlgorithmTester):
         if symmetric:
             # make data with both positive and negative peaks; roll so peaks are not overlapping
             y = np.roll(self.y, -50) - np.roll(self.y, 50)
+            p = 0.5
         else:
             y = self.y
-        self._test_output(y, y, symmetric=symmetric, checked_keys=('weights', 'tol_history'))
+            p = 0.01
+        self._test_output(y, y, p=p, symmetric=symmetric, checked_keys=('weights', 'tol_history'))
 
     def test_list_input(self):
         """Ensures that function works the same for both array and list inputs."""

--- a/tests/test_spline_utils.py
+++ b/tests/test_spline_utils.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""Tests for pybaselines._spline_utils.
+
+@author: Donald Erb
+Created on November 8, 2021
+
+"""
+
+from unittest import mock
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+import pytest
+from scipy.interpolate import BSpline, splev
+from scipy.sparse import diags, issparse, spdiags
+from scipy.sparse.linalg import spsolve
+
+from pybaselines import _algorithm_setup, _spline_utils
+
+
+def _nieve_basis_matrix(x, knots, spline_degree):
+    """Simple function for creating the basis matrix for a spline."""
+    num_bases = len(knots) - spline_degree - 1
+    basis = np.empty((num_bases, len(x)))
+    coeffs = np.zeros(num_bases)
+    # evaluate each single basis
+    for i in range(num_bases):
+        coeffs[i] = 1  # evaluate the i-th basis within splev
+        basis[i] = splev(x, (knots, coeffs, spline_degree))
+        coeffs[i] = 0  # reset back to zero
+
+    return basis.T
+
+
+def test_find_interval():
+    """Ensures the correct knot interval is identified when starting from left or right."""
+    spline_degree = 3
+    x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    # knots are range(0, 9) and extended on left and right with 3 extra values
+    knots = np.arange(-3, 13)
+    # indices within knots such that knots[index] <= x_i < knots[index + 1]; last
+    # knot is 11 rather than 12 since last index == number of basis functions
+    expected_indices = [3, 4, 5, 6, 7, 8, 9, 10, 11, 11]
+    len_knots = len(knots)
+    num_bases = len_knots - spline_degree - 1
+
+    left_indices = []
+    right_indices = []
+    for x_val in x:
+        # search starts at the left of the knot array
+        left_indices.append(
+            _spline_utils._find_interval(knots, spline_degree, x_val, 0, num_bases)
+        )
+        # search starts at the right of the knot array
+        right_indices.append(
+            _spline_utils._find_interval(knots, spline_degree, x_val, len_knots, num_bases)
+        )
+
+    assert_array_equal(left_indices, expected_indices)
+    assert_array_equal(right_indices, expected_indices)
+
+
+@pytest.mark.parametrize('num_knots', (2, 20, 1001))
+@pytest.mark.parametrize('spline_degree', (0, 1, 2, 3, 4, 5))
+@pytest.mark.parametrize('source', ('simple', 'numba', 'scipy'))
+def test_spline_basis(data_fixture, num_knots, spline_degree, source):
+    """Tests the accuracy of the spline basis matrix."""
+    if source == 'scipy' and not hasattr(BSpline, 'design_matrix'):
+        # BSpline.design_matrix not available until scipy 1.8.0
+        pytest.skip(
+            "BSpline.design_matrix is not available in the tested scipy version (must be >= 1.8.0)"
+        )
+
+    x, y = data_fixture
+    knots = _spline_utils._spline_knots(x, num_knots, spline_degree, True)
+
+    if source == 'scipy':
+        basis_func = BSpline.design_matrix
+    elif source == 'numba':
+        basis_func = _spline_utils._make_design_matrix
+    elif source == 'simple':
+        basis_func = _spline_utils._slow_design_matrix
+
+    basis = basis_func(x, knots, spline_degree)
+    expected_basis = _nieve_basis_matrix(x, knots, spline_degree)
+
+    assert basis.shape == (len(x), len(knots) - spline_degree - 1)
+
+    assert issparse(basis)
+    assert_allclose(basis.toarray(), expected_basis, 1e-10, 1e-12)
+    # also test the main interface for the spline basis
+    basis_2 = _spline_utils._spline_basis(x, knots, spline_degree)
+    assert issparse(basis_2)
+
+    assert_allclose(basis.toarray(), expected_basis, 1e-10, 1e-12)
+    assert_allclose(basis.toarray(), basis_2.toarray(), 1e-10, 1e-12)
+
+
+@pytest.mark.parametrize('num_knots', (2, 20, 1001))
+@pytest.mark.parametrize('spline_degree', (0, 1, 2, 3, 4, 5))
+def test_numba_basis_len(data_fixture, num_knots, spline_degree):
+    """
+    Checks the length of the data attribute of the spline basis csr matrix.
+
+    The `data` attribute of the csr matrix spline basis is used in a
+    function to quickly compute ``B.T @ B`` and ``B.T @ y`` without havig to
+    recreate the basis each iteration.
+
+    Only the numba spline basis is tested, since if numba is not installed,
+    the function is not used since it is much slower than other ways to compute
+    ``B.T @ B`` and ``B.T @ y`` which do not require the data length to be a
+    specific value.
+
+    """
+    x, y = data_fixture
+    knots = _spline_utils._spline_knots(x, num_knots, spline_degree, True)
+    basis = _spline_utils._make_design_matrix(x, knots, spline_degree)
+
+    assert len(basis.tocsr().data) == len(x) * (spline_degree + 1)
+
+
+def test_scipy_btb_bty(data_fixture):
+    """
+    Ensures the private function from Scipy works as intended.
+
+    If numba is not installed, the private function scipy.interpolate._bspl._norm_eq_lsq
+    is used to calculate ``B.T @ W @ B`` and ``B.T @ W @ y``.
+
+    This test is a "canary in the coal mine", and if it ever fails, the scipy
+    support will need to be looked at.
+
+    """
+    # import within this function in case this private file is ever renamed
+    from scipy.interpolate import _bspl
+    _scipy_btb_bty = _bspl._norm_eq_lsq
+
+    x, y = data_fixture
+    # ensure x and y are floats
+    x = x.astype(float, copy=False)
+    y = y.astype(float, copy=False)
+    # TODO replace with np.random.default_rng when min numpy version is >= 1.17
+    weights = np.random.RandomState(0).normal(0.8, 0.05, x.size)
+    weights = np.clip(weights, 0, 1).astype(float, copy=False)
+
+    spline_degree = 3
+    num_knots = 100
+
+    knots = _spline_utils._spline_knots(x, num_knots, spline_degree, True)
+    basis = _spline_utils._spline_basis(x, knots, spline_degree)
+    num_bases = basis.shape[1]
+
+    ab = np.zeros((spline_degree + 1, num_bases), order='F')
+    rhs = np.zeros((num_bases, 1), order='F')
+    _scipy_btb_bty(x, knots, spline_degree, y.reshape(-1, 1), np.sqrt(weights), ab, rhs)
+    rhs = rhs.reshape(-1)
+
+    expected_rhs = basis.T @ (weights * y)
+    expected_ab_full = (basis.T @ diags(weights, format='csr') @ basis).todia().data[::-1]
+    expected_ab_lower = expected_ab_full[len(expected_ab_full) // 2:]
+
+    assert_allclose(rhs, expected_rhs, 1e-10, 1e-12)
+    assert_allclose(ab, expected_ab_lower, 1e-10, 1e-12)
+
+
+@pytest.mark.parametrize('num_knots', (100, 1000))
+@pytest.mark.parametrize('spline_degree', (0, 1, 2, 3, 4, 5))
+@pytest.mark.parametrize('diff_order', (1, 2, 3, 4))
+def test_solve_psplines(data_fixture, num_knots, spline_degree, diff_order):
+    """
+    Tests the accuracy of the penalized spline solvers.
+
+    The penalized spline solver has three routes:
+    1) use the custom numba function (preferred if numba is installed)
+    2) use the scipy function scipy.interpolate._bspl._norm_eq_lsq (used if numba is
+       not installed and the scipy import works correctly)
+    3) compute ``B.T @ W @ B`` and ``B.T @ (w * y)`` using the sparse system (last resort)
+
+    All three are tested here.
+
+    """
+    x, y = data_fixture
+    # ensure x and y are floats
+    x = x.astype(float, copy=False)
+    y = y.astype(float, copy=False)
+    # TODO replace with np.random.default_rng when min numpy version is >= 1.17
+    weights = np.random.RandomState(0).normal(0.8, 0.05, x.size)
+    weights = np.clip(weights, 0, 1).astype(float, copy=False)
+
+    knots = _spline_utils._spline_knots(x, num_knots, spline_degree, True)
+    basis = _spline_utils._spline_basis(x, knots, spline_degree)
+    num_bases = basis.shape[1]
+    penalty = _algorithm_setup.diff_penalty_diagonals(num_bases, diff_order)
+    penalty_matrix = spdiags(
+        _algorithm_setup.diff_penalty_diagonals(num_bases, diff_order, False),
+        np.arange(diff_order, -(diff_order + 1), -1), num_bases, num_bases, 'csr'
+    )
+
+    expected_coeffs = spsolve(
+        basis.T @ diags(weights, format='csr') @ basis + penalty_matrix,
+        basis.T @ (weights * y)
+    )
+
+    with mock.patch.object(_spline_utils, '_HAS_NUMBA', True):
+        # should use the numba calculation
+        assert_allclose(
+            _spline_utils._solve_pspline(x, y, weights, basis, penalty, knots, spline_degree),
+            expected_coeffs, 1e-10, 1e-12
+        )
+
+    with mock.patch.object(_spline_utils, '_HAS_NUMBA', False):
+        # should use the scipy calculation
+        assert_allclose(
+            _spline_utils._solve_pspline(x, y, weights, basis, penalty, knots, spline_degree),
+            expected_coeffs, 1e-10, 1e-12
+        )
+
+        # mock that the scipy import failed; should use sparse calculation
+        with mock.patch.object(_spline_utils, '_scipy_btb_bty', None):
+            assert_allclose(
+                _spline_utils._solve_pspline(x, y, weights, basis, penalty, knots, spline_degree),
+                expected_coeffs, 1e-10, 1e-12
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -310,17 +310,6 @@ def test_difference_matrix_formats(form):
     assert utils.difference_matrix(10, 0, form).format == form
 
 
-def test_changing_pentapy_solver():
-    """Ensures a change to utils.PENTAPY_SOLVER is communicated by _pentapy_solver."""
-    original_solver = utils.PENTAPY_SOLVER
-    try:
-        for solver in range(5):
-            utils.PENTAPY_SOLVER = solver
-            assert utils._pentapy_solver() == solver
-    finally:
-        utils.PENTAPY_SOLVER = original_solver
-
-
 def pad_func(array, pad_width, axis, kwargs):
     """A custom padding function for use with numpy.pad."""
     pad_val = kwargs.get('pad_val', 0)

--- a/tests/test_whittaker.py
+++ b/tests/test_whittaker.py
@@ -12,7 +12,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
-from pybaselines import whittaker, utils
+from pybaselines import whittaker
 from pybaselines.utils import ParameterWarning
 
 from .conftest import AlgorithmTester, get_data, has_pentapy
@@ -58,17 +58,6 @@ def test_shift_rows_1_diag():
     assert_array_equal(expected, output)
     # matrix should also be shifted since the changes are done in-place
     assert_array_equal(expected, matrix)
-
-
-def test_changing_pentapy_solver():
-    """Ensures a change to utils.PENTAPY_SOLVER is communicated to pybaselines.whittaker."""
-    original_solver = utils.PENTAPY_SOLVER
-    try:
-        for solver in range(5):
-            utils.PENTAPY_SOLVER = solver
-            assert whittaker._pentapy_solver() == solver
-    finally:
-        utils.PENTAPY_SOLVER = original_solver
 
 
 class TestAsLS(AlgorithmTester):


### PR DESCRIPTION
<!--Please fill out all sections of the pull request template.-->

### Description
<!--Describe the pull request in detail, telling why the changes
are required and/or what problems they fix. Link or add the issue number
for any existing issues that the pull request solves.

Note that unsolicited pull requests will most likely be closed.
Please file an issue first, so that details can be discussed/finalized
before a pull request is created.-->
Switched the penalized spline functions to using a banded solver. Also adapted functions from scipy (added license) for creating the spline basis and for computing ``basis.T @ weights @ basis`` and ``basis.T @ weights @ y`` much faster than using the sparse system. Compared to version 0.7.0, the penalized spline functions are ~60-90% faster when numba is installed and ~10-50% faster without numba (the 10% is mpspline whose main time gain is the faster numba spline basis; once scipy version 1.8.0 is released with their Cython version for creating a spline basis, all functions should maintain their larger speedup even without numba).

### Type of Pull Request
<!--Put an x in all boxes that apply, like so: - [x] Bug Fix-->

- [ ] Bug Fix
- [x] New Feature
- [x] Miscellaneous Changes (refactor, code improvements, etc.)
- [ ] Documentation or Example Programs

### Pull Request Checklist
<!--Fill in all boxes with an x to verify.

To run tests locally, type the following command within the pybaselines
directory: pytest .

To lint files using flake8 to see if they pass PEP 8 standards and that
docstrings are okay, run the following command within the pybaselines
directory: flake8 .

To build documentation locally, type the following command within the
docs directory: make html
-->

- [x] New code and/or documentation is valid for use with the BSD 3-clause license.
- [x] New code is fully documented with docstrings that follow Numpy style,
      if applicable.
- [x] New code follows PEP 8 standards as closely as possible, if applicable.
- [x] Added/updated tests and ensured they pass locally, if applicable.
- [x] Verified that documentation builds locally, if applicable.
