### PR TITLE
OTHER: Allow alternate weighting schemes for aspls and lsrpls

### DIFF
--- a/docs/algorithms/spline.rst
+++ b/docs/algorithms/spline.rst
@@ -582,16 +582,15 @@ Weighting:
     w_i = \frac
         {1}
         {1 + \exp{\left(\frac
-            {k (r_i - \sigma^-)}
+            {k (r_i - \sigma^- + offset)}
             {\sigma^-}
         \right)}}
 
 where :math:`r_i = y_i - v_i`, :math:`\sigma^-` is the standard deviation
-of the negative values in the residual vector :math:`\mathbf r`, and :math:`k`
-is the asymmetric coefficient (Note that the default value of :math:`k` is 0.5 in
-pybaselines rather than 2 in the published version of the asPLS. pybaselines
-uses the factor of 0.5 since it matches the results in Table 2 and Figure 5
-of the asPLS paper closer than the factor of 2 and fits noisy data much better).
+of the negative values in the residual vector :math:`\mathbf r`, :math:`k`
+is the asymmetric coefficient, and `offset` is the mean of the negative values
+in the residual vector, :math:`\mu^-`, if ``alternate_weighting`` is True and
+0 if ``alternate_weighting`` is False.
 
 .. plot::
    :align: center
@@ -844,13 +843,15 @@ Weighting:
     w_i = \frac{1}{2}\left(
         1 -
         \frac
-            {10^t (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-}
-            {1 + \text{abs}[10^t (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-]}
+            {f(t) (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-}
+            {1 + \text{abs}[f(t) (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-]}
     \right)
 
-where :math:`r_i = y_i - v_i`, :math:`t` is the iteration number, and
+where :math:`r_i = y_i - v_i`, :math:`t` is the iteration number,
 :math:`\mu^-` and :math:`\sigma^-` are the mean and standard deviation,
-respectively, of the negative values in the residual vector :math:`\mathbf r`.
+respectively, of the negative values in the residual vector :math:`\mathbf r`,
+and :math:`f(t)` is :math:`10^t` if ``alternate_weighting`` is False and :math:`\exp(t)`
+if ``alternate_weighting`` is True.
 
 .. plot::
    :align: center

--- a/docs/algorithms/whittaker.rst
+++ b/docs/algorithms/whittaker.rst
@@ -505,16 +505,15 @@ Weighting:
     w_i = \frac
         {1}
         {1 + \exp{\left(\frac
-            {k (r_i - \sigma^-)}
+            {k (r_i - \sigma^- + offset)}
             {\sigma^-}
         \right)}}
 
 where :math:`r_i = y_i - v_i`, :math:`\sigma^-` is the standard deviation
-of the negative values in the residual vector :math:`\mathbf r`, and :math:`k`
-is the asymmetric coefficient (Note that the default value of :math:`k` is 0.5 in
-pybaselines rather than 2 in the published version of the asPLS. pybaselines
-uses the factor of 0.5 since it matches the results in Table 2 and Figure 5
-of the asPLS paper closer than the factor of 2 and fits noisy data much better).
+of the negative values in the residual vector :math:`\mathbf r`, :math:`k`
+is the asymmetric coefficient, and `offset` is the mean of the negative values
+in the residual vector, :math:`\mu^-`, if ``alternate_weighting`` is True and
+0 if ``alternate_weighting`` is False.
 
 .. plot::
    :align: center
@@ -722,13 +721,15 @@ Weighting:
     w_i = \frac{1}{2}\left(
         1 -
         \frac
-            {10^t (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-}
-            {1 + \text{abs}[10^t (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-]}
+            {f(t) (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-}
+            {1 + \text{abs}[f(t) (r_i - (-\mu^- + 2 \sigma^-))/\sigma^-]}
     \right)
 
-where :math:`r_i = y_i - v_i`, :math:`t` is the iteration number, and
+where :math:`r_i = y_i - v_i`, :math:`t` is the iteration number,
 :math:`\mu^-` and :math:`\sigma^-` are the mean and standard deviation,
-respectively, of the negative values in the residual vector :math:`\mathbf r`.
+respectively, of the negative values in the residual vector :math:`\mathbf r`,
+and :math:`f(t)` is :math:`10^t` if ``alternate_weighting`` is False and :math:`\exp(t)`
+if ``alternate_weighting`` is True.
 
 .. plot::
    :align: center

--- a/pybaselines/_weighting.py
+++ b/pybaselines/_weighting.py
@@ -312,7 +312,7 @@ def _iarpls(y, baseline, iteration):
     return weights, exit_early
 
 
-def _aspls(y, baseline, asymmetric_coef):
+def _aspls(y, baseline, asymmetric_coef, alternate_weighting):
     """
     Weighting for the adaptive smoothness penalized least squares smoothing (aspls).
 
@@ -322,9 +322,12 @@ def _aspls(y, baseline, asymmetric_coef):
         The measured data.
     baseline : numpy.ndarray, shape (N,)
         The calculated baseline.
-    asymmetric_coef : float
+    asymmetric_coef : float, optional
         The asymmetric coefficient for the weighting. Higher values leads to a steeper
-        weighting curve (ie. more step-like).
+        weighting curve (ie. more step-like). Default is 2.
+    alternate_weighting : bool, optional
+        If True (default), subtracts the mean of the negative residuals within the weighting
+        equation. If False, uses the weighting equation as stated within the aspls paper.
 
     Returns
     -------
@@ -363,8 +366,9 @@ def _aspls(y, baseline, asymmetric_coef):
         exit_early = False
     std = _safe_std(neg_residual, ddof=1)  # use dof=1 since sampling subset
 
+    shifted_residual = residual + neg_residual.mean() if alternate_weighting else residual
     # add a negative sign since expit performs 1/(1+exp(-input))
-    weights = expit(-(asymmetric_coef / std) * (residual - std))
+    weights = expit(-(asymmetric_coef / std) * (shifted_residual - std))
     return weights, residual, exit_early
 
 
@@ -582,7 +586,7 @@ def _brpls(y, baseline, beta):
     return weights, exit_early
 
 
-def _lsrpls(y, baseline, iteration):
+def _lsrpls(y, baseline, iteration, alternate_weighting):
     """
     The weighting for the locally symmetric reweighted penalized least squares (lsrpls).
 
@@ -595,6 +599,10 @@ def _lsrpls(y, baseline, iteration):
     iteration : int
         The iteration number. Should be 1-based, such that the first iteration is 1
         instead of 0.
+    alternate_weighting : bool, optional
+        If False (default), the weighting uses a prefactor term of ``10^t``, where ``t`` is
+        the iteration number, which is equation 8 within the LSRPLS paper [1]_. If True, uses
+        a prefactor term of ``exp(t)``. See the Notes section below for more details.
 
     Returns
     -------
@@ -604,12 +612,29 @@ def _lsrpls(y, baseline, iteration):
         Designates if there is a potential error with the calculation such that no further
         iterations should be performed.
 
+    Notes
+    -----
+    In the LSRPLS paper [1]_, the weighting equation is written with a prefactor term
+    of ``10^t``, where ``t`` is the iteration number, but the plotted weighting curve in
+    Figure 1 of the paper shows a prefactor term of ``exp(t)`` instead. Since it is ambiguous
+    which prefactor term is actually used for the algorithm, both are permitted by setting
+    `alternate_weighting` to True to use ``10^t`` and False to use ``exp(t)``. In practice,
+    the prefactor determines how quickly the weighting curve converts from a sigmoidal curve
+    to a step curve, and does not heavily influence the result.
+
+    If ``alternate_weighting`` is False, the weighting is the same as the drPLS algorithm [2]_.
+
     References
     ----------
-    Heng, Z., et al. Baseline correction for Raman Spectra Based on Locally Symmetric
-    Reweighted Penalized Least Squares. Chinese Journal of Lasers, 2018, 45(12), 1211001.
+    .. [1] Heng, Z., et al. Baseline correction for Raman Spectra Based on Locally Symmetric
+        Reweighted Penalized Least Squares. Chinese Journal of Lasers, 2018, 45(12), 1211001.
+    .. [2] Xu, D. et al. Baseline correction method based on doubly reweighted
+        penalized least squares, Applied Optics, 2019, 58, 3913-3920.
 
     """
+    if alternate_weighting:
+        return _drpls(y, baseline, iteration)
+
     residual = y - baseline
     neg_residual = residual[residual < 0]
     if neg_residual.size < 2:

--- a/pybaselines/_weighting.py
+++ b/pybaselines/_weighting.py
@@ -312,7 +312,7 @@ def _iarpls(y, baseline, iteration):
     return weights, exit_early
 
 
-def _aspls(y, baseline, asymmetric_coef, alternate_weighting):
+def _aspls(y, baseline, asymmetric_coef=2., alternate_weighting=True):
     """
     Weighting for the adaptive smoothness penalized least squares smoothing (aspls).
 
@@ -586,7 +586,7 @@ def _brpls(y, baseline, beta):
     return weights, exit_early
 
 
-def _lsrpls(y, baseline, iteration, alternate_weighting):
+def _lsrpls(y, baseline, iteration, alternate_weighting=False):
     """
     The weighting for the locally symmetric reweighted penalized least squares (lsrpls).
 

--- a/pybaselines/spline.py
+++ b/pybaselines/spline.py
@@ -916,7 +916,8 @@ class _Spline(_Algorithm):
 
     @_Algorithm._register(sort_keys=('weights', 'alpha'))
     def pspline_aspls(self, data, lam=1e4, num_knots=100, spline_degree=3, diff_order=2,
-                      max_iter=100, tol=1e-3, weights=None, alpha=None, asymmetric_coef=0.5):
+                      max_iter=100, tol=1e-3, weights=None, alpha=None, asymmetric_coef=2.,
+                      alternate_weighting=True):
         """
         A penalized spline version of the asPLS algorithm.
 
@@ -946,9 +947,16 @@ class _Spline(_Algorithm):
             An array of values that control the local value of `lam` to better
             fit peak and non-peak regions. If None (default), then the initial values
             will be an array with size equal to N and all values set to 1.
-        asymmetric_coef : float
+        asymmetric_coef : float, optional
             The asymmetric coefficient for the weighting. Higher values leads to a steeper
-            weighting curve (ie. more step-like). Default is 0.5.
+            weighting curve (ie. more step-like). Default is 2, as used in the asPLS paper [1]_.
+            Note that a value of 4 results in the weighting scheme used in the NasPLS
+            (Non-sensitive-areas adaptive smoothness penalized least squares smoothing) algorithm
+            [2]_.
+        alternate_weighting : bool, optional
+            If True (default), subtracts the mean of the negative residuals within the weighting
+            equation. If False, uses the weighting equation as stated within the asPLS paper [1]_.
+            See the Notes section below for more details.
 
         Returns
         -------
@@ -979,19 +987,25 @@ class _Spline(_Algorithm):
 
         Notes
         -----
-        The default asymmetric coefficient (`k` in the asPLS paper) is 0.5 instead
-        of the 2 listed in the asPLS paper. pybaselines uses the factor of 0.5 since it
-        matches the results in Table 2 and Figure 5 of the asPLS paper closer than the
-        factor of 2 and fits noisy data much better.
+        The weighting scheme as written in the asPLS paper [1]_ does not reproduce the paper's
+        results for noisy data. By subtracting the mean of negative residuals (``data-baseline``)
+        within the weighting scheme, as used by other algorithms such as ``arPLS`` and ``drPLS``,
+        the asPLS paper's results can be correctly replicated (see
+        https://github.com/derb12/pybaselines/issues/40 for more details). Given this discrepancy,
+        the default for ``aspls`` is to also subtract the negative residuals within the weighting.
+        To use the weighting scheme as it is written in the asPLS paper, simply set
+        ``alternate_weighting`` to False.
 
         References
         ----------
-        Zhang, F., et al. Baseline correction for infrared spectra using
-        adaptive smoothness parameter penalized least squares method.
-        Spectroscopy Letters, 2020, 53(3), 222-233.
-
-        Eilers, P., et al. Splines, knots, and penalties. Wiley Interdisciplinary
-        Reviews: Computational Statistics, 2010, 2(6), 637-653.
+        .. [1] Zhang, F., et al. Baseline correction for infrared spectra using
+            adaptive smoothness parameter penalized least squares method.
+            Spectroscopy Letters, 2020, 53(3), 222-233.
+        .. [2] Zhang, F., et al. An automatic baseline correction method based on reweighted
+            penalized least squares method for non-sensitive areas. Vibrational Spectroscopy,
+            2025, 138, 103806.
+        .. [3] Eilers, P., et al. Splines, knots, and penalties. Wiley Interdisciplinary
+            Reviews: Computational Statistics, 2010, 2(6), 637-653.
 
         """
         y, weight_array, pspline = self._setup_spline(
@@ -1014,7 +1028,9 @@ class _Spline(_Algorithm):
                 pspline.num_bands, pspline.num_bands
             )
             baseline = pspline.solve_pspline(y, weight_array, alpha_penalty)
-            new_weights, residual, exit_early = _weighting._aspls(y, baseline, asymmetric_coef)
+            new_weights, residual, exit_early = _weighting._aspls(
+                y, baseline, asymmetric_coef, alternate_weighting
+            )
             if exit_early:
                 i -= 1  # reduce i so that output tol_history indexing is correct
                 break
@@ -1507,7 +1523,7 @@ class _Spline(_Algorithm):
 
     @_Algorithm._register(sort_keys=('weights',))
     def pspline_lsrpls(self, data, lam=1e3, num_knots=100, spline_degree=3, diff_order=2,
-                       max_iter=50, tol=1e-3, weights=None):
+                       max_iter=50, tol=1e-3, weights=None, alternate_weighting=False):
         """
         A penalized spline version of the LSRPLS algorithm.
 
@@ -1533,6 +1549,10 @@ class _Spline(_Algorithm):
         weights : array-like, shape (N,), optional
             The weighting array. If None (default), then the initial weights
             will be an array with size equal to N and all values set to 1.
+        alternate_weighting : bool, optional
+            If False (default), the weighting uses a prefactor term of ``10^t``, where ``t`` is
+            the iteration number, which is equation 8 within the LSRPLS paper [1]_. If True, uses
+            a prefactor term of ``exp(t)``. See the Notes section below for more details.
 
         Returns
         -------
@@ -1553,10 +1573,24 @@ class _Spline(_Algorithm):
         --------
         Baseline.lsrpls
 
+        Notes
+        -----
+        In the LSRPLS paper [1]_, the weighting equation is written with a prefactor term
+        of ``10^t``, where ``t`` is the iteration number, but the plotted weighting curve in
+        Figure 1 of the paper shows a prefactor term of ``exp(t)`` instead. Since it is ambiguous
+        which prefactor term is actually used for the algorithm, both are permitted by setting
+        `alternate_weighting` to True to use ``10^t`` and False to use ``exp(t)``. In practice,
+        the prefactor determines how quickly the weighting curve converts from a sigmoidal curve
+        to a step curve, and does not heavily influence the result.
+
+        If ``alternate_weighting`` is False, the weighting is the same as the drPLS algorithm [2]_.
+
         References
         ----------
-        Heng, Z., et al. Baseline correction for Raman Spectra Based on Locally Symmetric
-        Reweighted Penalized Least Squares. Chinese Journal of Lasers, 2018, 45(12), 1211001.
+        .. [1] Heng, Z., et al. Baseline correction for Raman Spectra Based on Locally Symmetric
+            Reweighted Penalized Least Squares. Chinese Journal of Lasers, 2018, 45(12), 1211001.
+        .. [2] Xu, D. et al. Baseline correction method based on doubly reweighted
+            penalized least squares, Applied Optics, 2019, 58, 3913-3920.
 
         """
         y, weight_array, pspline = self._setup_spline(
@@ -1565,7 +1599,7 @@ class _Spline(_Algorithm):
         tol_history = np.empty(max_iter + 1)
         for i in range(1, max_iter + 2):
             baseline = pspline.solve_pspline(y, weight_array)
-            new_weights, exit_early = _weighting._lsrpls(y, baseline, i)
+            new_weights, exit_early = _weighting._lsrpls(y, baseline, i, alternate_weighting)
             if exit_early:
                 i -= 1  # reduce i so that output tol_history indexing is correct
                 break
@@ -2329,7 +2363,7 @@ def pspline_iarpls(data, lam=1e3, num_knots=100, spline_degree=3, diff_order=2,
 @_spline_wrapper
 def pspline_aspls(data, lam=1e4, num_knots=100, spline_degree=3, diff_order=2,
                   max_iter=100, tol=1e-3, weights=None, alpha=None, x_data=None,
-                  asymmetric_coef=0.5):
+                  asymmetric_coef=2., alternate_weighting=True):
     """
     A penalized spline version of the asPLS algorithm.
 
@@ -2362,9 +2396,16 @@ def pspline_aspls(data, lam=1e4, num_knots=100, spline_degree=3, diff_order=2,
     x_data : array-like, shape (N,), optional
         The x-values of the measured data. Default is None, which will create an
         array from -1 to 1 with N points.
-    asymmetric_coef : float
+    asymmetric_coef : float, optional
         The asymmetric coefficient for the weighting. Higher values leads to a steeper
-        weighting curve (ie. more step-like). Default is 0.5.
+        weighting curve (ie. more step-like). Default is 2, as used in the asPLS paper [1]_.
+        Note that a value of 4 results in the weighting scheme used in the NasPLS
+        (Non-sensitive-areas adaptive smoothness penalized least squares smoothing) algorithm
+        [2]_.
+    alternate_weighting : bool, optional
+        If True (default), subtracts the mean of the negative residuals within the weighting
+        equation. If False, uses the weighting equation as stated within the asPLS paper [1]_.
+        See the Notes section below for more details.
 
     Returns
     -------
@@ -2395,19 +2436,25 @@ def pspline_aspls(data, lam=1e4, num_knots=100, spline_degree=3, diff_order=2,
 
     Notes
     -----
-    The default asymmetric coefficient (`k` in the asPLS paper) is 0.5 instead
-    of the 2 listed in the asPLS paper. pybaselines uses the factor of 0.5 since it
-    matches the results in Table 2 and Figure 5 of the asPLS paper closer than the
-    factor of 2 and fits noisy data much better.
+    The weighting scheme as written in the asPLS paper [1]_ does not reproduce the paper's
+    results for noisy data. By subtracting the mean of negative residuals (``data-baseline``)
+    within the weighting scheme, as used by other algorithms such as ``arPLS`` and ``drPLS``,
+    the asPLS paper's results can be correctly replicated (see
+    https://github.com/derb12/pybaselines/issues/40 for more details). Given this discrepancy,
+    the default for ``aspls`` is to also subtract the negative residuals within the weighting.
+    To use the weighting scheme as it is written in the asPLS paper, simply set
+    ``alternate_weighting`` to False.
 
     References
     ----------
-    Zhang, F., et al. Baseline correction for infrared spectra using
-    adaptive smoothness parameter penalized least squares method.
-    Spectroscopy Letters, 2020, 53(3), 222-233.
-
-    Eilers, P., et al. Splines, knots, and penalties. Wiley Interdisciplinary
-    Reviews: Computational Statistics, 2010, 2(6), 637-653.
+    .. [1] Zhang, F., et al. Baseline correction for infrared spectra using
+        adaptive smoothness parameter penalized least squares method.
+        Spectroscopy Letters, 2020, 53(3), 222-233.
+    .. [2] Zhang, F., et al. An automatic baseline correction method based on reweighted
+        penalized least squares method for non-sensitive areas. Vibrational Spectroscopy,
+        2025, 138, 103806.
+    .. [3] Eilers, P., et al. Splines, knots, and penalties. Wiley Interdisciplinary
+        Reviews: Computational Statistics, 2010, 2(6), 637-653.
 
     """
 
@@ -2742,7 +2789,7 @@ def pspline_brpls(data, x_data=None, lam=1e3, num_knots=100, spline_degree=3, di
 
 @_spline_wrapper
 def pspline_lsrpls(data, x_data=None, lam=1e3, num_knots=100, spline_degree=3, diff_order=2,
-                   max_iter=50, tol=1e-3, weights=None):
+                   max_iter=50, tol=1e-3, weights=None, alternate_weighting=False):
     """
     A penalized spline version of the LSRPLS algorithm.
 
@@ -2771,6 +2818,10 @@ def pspline_lsrpls(data, x_data=None, lam=1e3, num_knots=100, spline_degree=3, d
     weights : array-like, shape (N,), optional
         The weighting array. If None (default), then the initial weights
         will be an array with size equal to N and all values set to 1.
+    alternate_weighting : bool, optional
+        If False (default), the weighting uses a prefactor term of ``10^t``, where ``t`` is
+        the iteration number, which is equation 8 within the LSRPLS paper [1]_. If True, uses
+        a prefactor term of ``exp(t)``. See the Notes section below for more details.
 
     Returns
     -------
@@ -2791,9 +2842,23 @@ def pspline_lsrpls(data, x_data=None, lam=1e3, num_knots=100, spline_degree=3, d
     --------
     Baseline.lsrpls
 
+    Notes
+    -----
+    In the LSRPLS paper [1]_, the weighting equation is written with a prefactor term
+    of ``10^t``, where ``t`` is the iteration number, but the plotted weighting curve in
+    Figure 1 of the paper shows a prefactor term of ``exp(t)`` instead. Since it is ambiguous
+    which prefactor term is actually used for the algorithm, both are permitted by setting
+    `alternate_weighting` to True to use ``10^t`` and False to use ``exp(t)``. In practice,
+    the prefactor determines how quickly the weighting curve converts from a sigmoidal curve
+    to a step curve, and does not heavily influence the result.
+
+    If ``alternate_weighting`` is False, the weighting is the same as the drPLS algorithm [2]_.
+
     References
     ----------
-    Heng, Z., et al. Baseline correction for Raman Spectra Based on Locally Symmetric
-    Reweighted Penalized Least Squares. Chinese Journal of Lasers, 2018, 45(12), 1211001.
+    .. [1] Heng, Z., et al. Baseline correction for Raman Spectra Based on Locally Symmetric
+        Reweighted Penalized Least Squares. Chinese Journal of Lasers, 2018, 45(12), 1211001.
+    .. [2] Xu, D. et al. Baseline correction method based on doubly reweighted
+        penalized least squares, Applied Optics, 2019, 58, 3913-3920.
 
     """

--- a/pybaselines/spline.py
+++ b/pybaselines/spline.py
@@ -953,10 +953,15 @@ class _Spline(_Algorithm):
             Note that a value of 4 results in the weighting scheme used in the NasPLS
             (Non-sensitive-areas adaptive smoothness penalized least squares smoothing) algorithm
             [2]_.
+
+            .. versionadded:: 1.2.0
+
         alternate_weighting : bool, optional
             If True (default), subtracts the mean of the negative residuals within the weighting
             equation. If False, uses the weighting equation as stated within the asPLS paper [1]_.
             See the Notes section below for more details.
+
+            .. versionadded:: 1.3.0
 
         Returns
         -------
@@ -988,13 +993,12 @@ class _Spline(_Algorithm):
         Notes
         -----
         The weighting scheme as written in the asPLS paper [1]_ does not reproduce the paper's
-        results for noisy data. By subtracting the mean of negative residuals (``data-baseline``)
-        within the weighting scheme, as used by other algorithms such as ``arPLS`` and ``drPLS``,
-        the asPLS paper's results can be correctly replicated (see
-        https://github.com/derb12/pybaselines/issues/40 for more details). Given this discrepancy,
-        the default for ``aspls`` is to also subtract the negative residuals within the weighting.
-        To use the weighting scheme as it is written in the asPLS paper, simply set
-        ``alternate_weighting`` to False.
+        results for noisy data. By subtracting the mean of negative residuals (ie. the negative
+        values of ``data - baseline``) within the weighting scheme, the asPLS paper's results can
+        be correctly replicated (see https://github.com/derb12/pybaselines/issues/40 for more
+        details). Given this discrepancy, the default for ``pspline_aspls`` is to also subtract the
+        negative residuals within the weighting. To use the weighting scheme as it is written in
+        the asPLS paper, set ``alternate_weighting`` to False.
 
         References
         ----------
@@ -1553,6 +1557,8 @@ class _Spline(_Algorithm):
             If False (default), the weighting uses a prefactor term of ``10^t``, where ``t`` is
             the iteration number, which is equation 8 within the LSRPLS paper [1]_. If True, uses
             a prefactor term of ``exp(t)``. See the Notes section below for more details.
+
+            .. versionadded:: 1.3.0
 
         Returns
         -------

--- a/pybaselines/two_d/spline.py
+++ b/pybaselines/two_d/spline.py
@@ -981,6 +981,8 @@ class _Spline(_Algorithm2D):
             the iteration number, which is equation 8 within the LSRPLS paper [1]_. If True, uses
             a prefactor term of ``exp(t)``. See the Notes section below for more details.
 
+            .. versionadded:: 1.3.0
+
         Returns
         -------
         baseline : numpy.ndarray, shape (M, N)

--- a/pybaselines/two_d/whittaker.py
+++ b/pybaselines/two_d/whittaker.py
@@ -624,10 +624,15 @@ class _Whittaker(_Algorithm2D):
             Note that a value of 4 results in the weighting scheme used in the NasPLS
             (Non-sensitive-areas adaptive smoothness penalized least squares smoothing) algorithm
             [2]_.
+
+            .. versionadded:: 1.2.0
+
         alternate_weighting : bool, optional
             If True (default), subtracts the mean of the negative residuals within the weighting
             equation. If False, uses the weighting equation as stated within the asPLS paper [1]_.
             See the Notes section below for more details.
+
+            .. versionadded:: 1.3.0
 
         Returns
         -------
@@ -655,13 +660,12 @@ class _Whittaker(_Algorithm2D):
         Notes
         -----
         The weighting scheme as written in the asPLS paper [1]_ does not reproduce the paper's
-        results for noisy data. By subtracting the mean of negative residuals (``data-baseline``)
-        within the weighting scheme, as used by other algorithms such as ``arPLS`` and ``drPLS``,
-        the asPLS paper's results can be correctly replicated (see
-        https://github.com/derb12/pybaselines/issues/40 for more details). Given this discrepancy,
-        the default for ``aspls`` is to also subtract the negative residuals within the weighting.
-        To use the weighting scheme as it is written in the asPLS paper, simply set
-        ``alternate_weighting`` to False.
+        results for noisy data. By subtracting the mean of negative residuals (ie. the negative
+        values of ``data - baseline``) within the weighting scheme, the asPLS paper's results can
+        be correctly replicated (see https://github.com/derb12/pybaselines/issues/40 for more
+        details). Given this discrepancy, the default for ``aspls`` is to also subtract the
+        negative residuals within the weighting. To use the weighting scheme as it is written in
+        the asPLS paper, set ``alternate_weighting`` to False.
 
         References
         ----------
@@ -1003,6 +1007,8 @@ class _Whittaker(_Algorithm2D):
             If False (default), the weighting uses a prefactor term of ``10^t``, where ``t`` is
             the iteration number, which is equation 8 within the LSRPLS paper [1]_. If True, uses
             a prefactor term of ``exp(t)``. See the Notes section below for more details.
+
+            .. versionadded:: 1.3.0
 
         Returns
         -------

--- a/pybaselines/whittaker.py
+++ b/pybaselines/whittaker.py
@@ -535,10 +535,15 @@ class _Whittaker(_Algorithm):
             Note that a value of 4 results in the weighting scheme used in the NasPLS
             (Non-sensitive-areas adaptive smoothness penalized least squares smoothing) algorithm
             [2]_.
+
+            .. versionadded:: 1.2.0
+
         alternate_weighting : bool, optional
             If True (default), subtracts the mean of the negative residuals within the weighting
             equation. If False, uses the weighting equation as stated within the asPLS paper [1]_.
             See the Notes section below for more details.
+
+            .. versionadded:: 1.3.0
 
         Returns
         -------
@@ -566,13 +571,12 @@ class _Whittaker(_Algorithm):
         Notes
         -----
         The weighting scheme as written in the asPLS paper [1]_ does not reproduce the paper's
-        results for noisy data. By subtracting the mean of negative residuals (``data-baseline``)
-        within the weighting scheme, as used by other algorithms such as ``arPLS`` and ``drPLS``,
-        the asPLS paper's results can be correctly replicated (see
-        https://github.com/derb12/pybaselines/issues/40 for more details). Given this discrepancy,
-        the default for ``aspls`` is to also subtract the negative residuals within the weighting.
-        To use the weighting scheme as it is written in the asPLS paper, simply set
-        ``alternate_weighting`` to False.
+        results for noisy data. By subtracting the mean of negative residuals (ie. the negative
+        values of ``data - baseline``) within the weighting scheme, the asPLS paper's results can
+        be correctly replicated (see https://github.com/derb12/pybaselines/issues/40 for more
+        details). Given this discrepancy, the default for ``aspls`` is to also subtract the
+        negative residuals within the weighting. To use the weighting scheme as it is written in
+        the asPLS paper, set ``alternate_weighting`` to False.
 
         References
         ----------
@@ -982,6 +986,8 @@ class _Whittaker(_Algorithm):
             If False (default), the weighting uses a prefactor term of ``10^t``, where ``t`` is
             the iteration number, which is equation 8 within the LSRPLS paper [1]_. If True, uses
             a prefactor term of ``exp(t)``. See the Notes section below for more details.
+
+            .. versionadded:: 1.3.0
 
         Returns
         -------

--- a/tests/test_whittaker.py
+++ b/tests/test_whittaker.py
@@ -62,7 +62,8 @@ def sparse_drpls(data, lam, eta=0.5, diff_order=2, tol=1e-3, max_iter=50):
     return baseline
 
 
-def sparse_aspls(data, lam, diff_order=2, tol=1e-3, max_iter=100, asymmetric_coef=2):
+def sparse_aspls(data, lam, diff_order=2, tol=1e-3, max_iter=100, asymmetric_coef=2.,
+                 alternate_weighting=True):
     """A sparse version of aspls for testing that the banded version is implemented correctly."""
     y = np.asarray(data)
     num_y = len(y)
@@ -74,7 +75,9 @@ def sparse_aspls(data, lam, diff_order=2, tol=1e-3, max_iter=100, asymmetric_coe
     for _ in range(max_iter + 1):
         lhs = weight_matrix + alpha_matrix @ penalty_matrix
         baseline = spsolve(lhs, weight_array * y)
-        new_weights, residual, _ = _weighting._aspls(y, baseline, asymmetric_coef)
+        new_weights, residual, _ = _weighting._aspls(
+            y, baseline, asymmetric_coef, alternate_weighting
+        )
         if relative_difference(weight_array, new_weights) < tol:
             break
         weight_array = new_weights
@@ -424,9 +427,10 @@ class TestAsPLS(WhittakerTester):
         with pytest.raises(ValueError):
             self.class_func(self.y, asymmetric_coef=asymmetric_coef)
 
-    @pytest.mark.parametrize('asymmetric_coef', (1, 2))
+    @pytest.mark.parametrize('asymmetric_coef', (0.5, 2, 4))
+    @pytest.mark.parametrize('alternate_weighting', (True, False))
     @pytest.mark.parametrize('diff_order', (2, 3))
-    def test_sparse_comparison(self, diff_order, asymmetric_coef):
+    def test_sparse_comparison(self, diff_order, asymmetric_coef, alternate_weighting):
         """
         Ensures the banded version of the implementation is correct.
 
@@ -438,14 +442,14 @@ class TestAsPLS(WhittakerTester):
         lam = {2: 1e7, 3: 1e10}[diff_order]
         sparse_output = sparse_aspls(
             self.y, lam=lam, diff_order=diff_order, max_iter=max_iter, tol=tol,
-            asymmetric_coef=asymmetric_coef
+            asymmetric_coef=asymmetric_coef, alternate_weighting=alternate_weighting
         )
         banded_output = self.class_func(
             self.y, lam=lam, diff_order=diff_order, max_iter=max_iter, tol=tol,
-            asymmetric_coef=asymmetric_coef
+            asymmetric_coef=asymmetric_coef, alternate_weighting=alternate_weighting
         )[0]
 
-        rtol = {2: 1e-4, 3: 2e-4}[diff_order]
+        rtol = {2: 1e-4, 3: 5e-4}[diff_order]
         assert_allclose(banded_output, sparse_output, rtol=rtol, atol=1e-8)
 
 


### PR DESCRIPTION
<!--Please fill out all sections of the pull request template.-->

### Description
<!--Describe the pull request in detail, telling why the changes
are required and/or what problems they fix. Link or add the issue number
for any existing issues that the pull request solves.

Note that it is preferred to file an issue first, so that details can be
discussed/finalized before a pull request is created.-->
Provides a toggle to allow different weighting schemes for ``aspls`` and ``lsrpls`` (and their pspline and 2D versions). Made the new weighting scheme the default for ``aspls`` and kept the original scheme the default for ``lsrpls``. Closes issue #40.

### Type of Pull Request
<!--Put an x in all boxes that apply, like so: - [x] Bug Fix-->

- [ ] Bug Fix
- [x] New Feature
- [ ] Miscellaneous Changes (refactor, code improvements, etc.)
- [x] Documentation or Example Programs

### Pull Request Checklist
<!--Fill in all boxes with an x to verify.

To run tests locally, type the following command within the pybaselines
directory: pytest .

To lint files using ruff to see if they pass PEP 8 standards and that
docstrings are okay, run the following command within the pybaselines
directory: ruff check .

To build documentation locally, type the following command within the
docs directory: make html
-->

- [x] New code and/or documentation is valid for use with the BSD 3-clause license.
- [x] New code is fully documented with docstrings that follow Numpy style,
      if applicable.
- [x] New code follows PEP 8 standards as closely as possible, if applicable.
- [x] Added/updated tests and ensured they pass locally, if applicable.
- [x] Verified that documentation builds locally, if applicable.
