### PR TITLE
OTHER: Vendor pentapy's solvers

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -98,7 +98,7 @@ jobs:
       run: pytest .
 
     - name: Install minimum optional dependencies
-      run: python -m pip install "pentapy==1.1.*" "numba==0.53.*"
+      run: python -m pip install "numba==0.53.*"
 
     - name: Test with minimum optional dependencies
       run: pytest .

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -166,8 +166,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-Source: pentapy (https://github.com/GeoStat-Framework/pentapy, last accessed March 25, 2025)
-Functions: pybaselines._banded_solvers.ptrans_1 and pybaselines._banded_solvers.ptrans_2
+Source: pentapy (https://github.com/GeoStat-Framework/pentapy, last accessed September 26, 2025)
+Files: pybaselines._banded_solvers.py and tests/test_banded_solvers.py
 License: MIT
 
 The MIT License (MIT)

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -164,3 +164,30 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Source: pentapy (https://github.com/GeoStat-Framework/pentapy, last accessed March 25, 2025)
+Functions: pybaselines._banded_solvers.ptrans_1 and pybaselines._banded_solvers.ptrans_2
+License: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Sebastian Müller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,7 +116,6 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
-    'pentapy': ('https://geostat-framework.readthedocs.io/projects/pentapy/en/stable/', None)
 }
 
 # cache remote doc inventories for 14 days

--- a/docs/examples/whittaker/plot_whittaker_solvers.py
+++ b/docs/examples/whittaker/plot_whittaker_solvers.py
@@ -8,18 +8,18 @@ the banded structure of the linear system to reduce the computation time.
 
 This example shows the difference in computation times of the asymmetic least squares
 (:meth:`~.Baseline.asls`) algorithm when using the banded solver from SciPy,
-:func:`scipy.linalg.solve_banded`, and the banded solver from the optional dependency
-`pentapy <https://github.com/GeoStat-Framework/pentapy>`_. In addition, the time
-it takes when solving the system using sparse matrices rather than the banded matrices
-is compared, since direct adaptation from literature usually uses the sparse solution.
+:func:`scipy.linalg.solve_banded`, and a dedicated pentadiagonal banded solver derived
+from the excellent `pentapy <https://github.com/GeoStat-Framework/pentapy>`_ package. In
+addition, the time it takes when solving the system using sparse matrices rather than the banded
+matrices is compared, since direct adaptations from literature usually use the sparse solution.
 All three of these solvers are based on LU decomposition. Since the asls algorithm results
-in a symmetric, positive-definite left-hand side of the normal equation, it can additionally
-be solved using Cholesky decomposition through the dedicated SciPy solver
+in a symmetric, positive-definite left hand side of the normal equation, it can additionally
+be solved using Thomas' algorithm through the dedicated SciPy solver
 :func:`scipy.linalg.solveh_banded`.
 
 Compared to the time required to solve using sparse matrices, SciPy's banded solvers
-are ~50-80% faster and pentapy's banded solver is ~70-90% faster, ultimately reducing
-the computation time by about an order of magnitude.
+are ~50-80% faster and the dedicated pentadiagonal banded solver is ~70-90% faster, ultimately
+reducing the computation time by about an order of magnitude.
 
 Note that the performance of solving this particular sparse system can be improved by using
 the sparse Cholesky decomposition solver
@@ -79,10 +79,10 @@ def sparse_asls(data, lam=1e6, p=1e-2, diff_order=2, max_iter=50, tol=1e-3, weig
 if __name__ == '__main__':
 
     try:
-        import pentapy  # noqa
+        import numba  # noqa
     except ImportError:
         warnings.warn(
-            'pentapy is not installed so pentapy and solveh_banded timings will be identical',
+            'numba is not installed so pentadiagonal and solveh_banded timings will be identical',
             stacklevel=2
         )
 
@@ -93,11 +93,11 @@ if __name__ == '__main__':
         'sparse',
         'solve_banded',
         'solveh_banded',
-        'pentapy',
+        'pentadiagonal'
     )
     # solver_numbers corresponds to the settings for the `banded_solver` attribute of
-    # Baseline objects for each of the solvers; pentapy could be 1 or 2
-    solver_numbers = {'solve_banded': 4, 'solveh_banded': 3, 'pentapy': 2}
+    # Baseline objects for each of the solvers; pentadiagonal could be 1 or 2
+    solver_numbers = {'solve_banded': 4, 'solveh_banded': 3, 'pentadiagonal': 2}
     func_timings = {}
     data_sizes = np.logspace(np.log10(500), np.log10(40000), 8, dtype=int)
     for func_name in functions:
@@ -131,9 +131,10 @@ if __name__ == '__main__':
     plt.ylabel('Median Time (seconds)')
     plt.legend()
 
-    # The relative time reduced by using pentapy can be compared for each of the other methods
+    # The relative time reduced by using the pentadiagonal solver can be compared for each
+    # of the other methods
     plt.figure()
-    reference_key = 'pentapy'
+    reference_key = 'pentadiagonal'
     reference_times = func_timings[reference_key]
     for key, values in func_timings.items():
         if key == reference_key:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ Optional Dependencies
 pybaselines has the following optional dependencies:
 
 * `Numba <https://github.com/numba/numba>`_ (>= 0.53):
-  speeds up calculations used by the following functions:
+  speeds up calculations used by the following methods:
 
     * :meth:`~.Baseline.loess`
     * :meth:`~.Baseline.dietrich`
@@ -32,16 +32,11 @@ pybaselines has the following optional dependencies:
     * :meth:`~.Baseline.fastchrom`
     * :meth:`~.Baseline.beads`
     * :meth:`~.Baseline.mpspline`
-    * all :ref:`spline <api/Baseline:Spline Algorithms>` methods
-
-* `pentapy <https://github.com/GeoStat-Framework/pentapy>`_ (>= 1.1):
-  provides a faster solver for banded pentadiagonal linear systems, which are
-  used by the following functions (when ``diff_order=2``):
-
-    * all :ref:`Whittaker smoothing <api/Baseline:Whittaker Smoothing Algorithms>` methods
     * :meth:`~.Baseline.mpls`
     * :meth:`~.Baseline.jbcd`
     * :meth:`~.Baseline.fabc`
+    * all :ref:`spline <api/Baseline:Spline Algorithms>` methods
+    * all :ref:`Whittaker smoothing <api/Baseline:Whittaker Smoothing Algorithms>` methods
 
 
 Stable Release

--- a/pybaselines/_algorithm_setup.py
+++ b/pybaselines/_algorithm_setup.py
@@ -179,7 +179,7 @@ class _Algorithm:
         """
         if isinstance(solver, bool) or solver not in {1, 2, 3, 4}:
             # catch True since it can be interpreted as in {1, 2, 3, 4}; would likely
-            # not cause issues downsteam, but just eliminate that possibility
+            # not cause issues downstream, but just eliminate that possibility
             raise ValueError('banded_solver must be an integer with a value in (1, 2, 3, 4)')
         self._banded_solver = solver
         if solver < 3:
@@ -369,7 +369,7 @@ class _Algorithm:
         return new_object
 
     def _setup_whittaker(self, y, lam=1, diff_order=2, weights=None, copy_weights=False,
-                         allow_lower=True, reverse_diags=None):
+                         allow_lower=True, reverse_diags=False):
         """
         Sets the starting parameters for doing penalized least squares.
 
@@ -393,10 +393,9 @@ class _Algorithm:
         allow_lower : boolean, optional
             If True (default), will allow using only the lower non-zero diagonals of
             the squared difference matrix. If False, will include all non-zero diagonals.
-        reverse_diags : {None, False, True}, optional
+        reverse_diags : bool, optional
             If True, will reverse the order of the diagonals of the squared difference
-            matrix. If False, will never reverse the diagonals. If None (default), will
-            only reverse the diagonals if using pentapy's solver.
+            matrix. Default is False.
 
         Returns
         -------

--- a/pybaselines/_algorithm_setup.py
+++ b/pybaselines/_algorithm_setup.py
@@ -140,17 +140,26 @@ class _Algorithm:
 
         .. versionadded:: 1.2.0
 
-        An integer between 1 and 4 designating the solver to prefer for solving banded
-        linear systems. Setting to 1 or 2 will use the ``PTRANS-I``
-        and ``PTRANS-II`` solvers, respectively, from :func:`pentapy.solve` if
-        ``pentapy`` is installed and the linear system is pentadiagonal. Otherwise,
-        it will use :func:`scipy.linalg.solveh_banded` if the system is symmetric,
-        else :func:`scipy.linalg.solve_banded`. Setting ``banded_solver`` to 3
-        will only use the SciPy solvers following the same logic, and 4 will
-        force usage of :func:`scipy.linalg.solve_banded`. Default is 2.
+        An integer designating the solver. Setting to 1 or 2 will use the ``PTRANS-I``
+        and ``PTRANS-II`` solvers, respectively, from [1]_ if ``numba`` is installed
+        and the linear system is pentadiagonal. Otherwise, it will use
+        :func:`scipy.linalg.solveh_banded` if the system is symmetric, else
+        :func:`scipy.linalg.solve_banded`. Setting ``banded_solver`` to 3 will only
+        use the SciPy solvers following the same logic, and 4 will force usage of
+        :func:`scipy.linalg.solve_banded`. Default is 2
 
-        This typically does not need to be modified since all solvers have relatively
-        the same numerical stability and is mostly for internal testing.
+        PTRANS-I and PTRANS-II are the fastest, and solve_banded is the slowest. In terms
+        of numerical stability, solveh_banded is the least stable, PTRANS-I and PTRANS-II
+        are slightly more stable (LU factorization without pivoting), and solve_banded (LU
+        factorization with partial pivoting) is the most stable. In practice, however,
+        instability rarely occurs during baseline correction and should be avoided through
+        other means (eg. switching from Whittaker-smoothing methods to penalized spline
+        methods in order to lower the required `lam` parameter).
+
+        References
+        ----------
+        .. [1] Askar, S., et al. On Solving Pentadiagonal Linear Systems via
+            Transformations. Mathematical Problems in Engineering, 2015, 232456.
 
         """
         return self._banded_solver
@@ -158,23 +167,28 @@ class _Algorithm:
     @banded_solver.setter
     def banded_solver(self, solver):
         """
-        Sets the solver for banded systems and the solver for the optional dependency pentapy.
+        Sets the solver to use for banded linear systems.
 
         Parameters
         ----------
         solver : {1, 2, 3, 4}
             An integer designating the solver. Setting to 1 or 2 will use the ``PTRANS-I``
-            and ``PTRANS-II`` solvers, respectively, from :func:`pentapy.solve` if
-            ``pentapy`` is installed and the linear system is pentadiagonal. Otherwise,
-            it will use :func:`scipy.linalg.solveh_banded` if the system is symmetric,
-            else :func:`scipy.linalg.solve_banded`. Setting ``banded_solver`` to 3
-            will only use the SciPy solvers following the same logic, and 4 will
-            force usage of :func:`scipy.linalg.solve_banded`.
+            and ``PTRANS-II`` solvers, respectively, from [1]_ if ``numba`` is installed
+            and the linear system is pentadiagonal. Otherwise, it will use
+            :func:`scipy.linalg.solveh_banded` if the system is symmetric, else
+            :func:`scipy.linalg.solve_banded`. Setting ``banded_solver`` to 3 will only
+            use the SciPy solvers following the same logic, and 4 will force usage of
+            :func:`scipy.linalg.solve_banded`.
 
         Raises
         ------
         ValueError
             Raised if `solver` is not an integer between 1 and 4.
+
+        References
+        ----------
+        .. [1] Askar, S., et al. On Solving Pentadiagonal Linear Systems via
+            Transformations. Mathematical Problems in Engineering, 2015, 232456.
 
         """
         if isinstance(solver, bool) or solver not in {1, 2, 3, 4}:
@@ -190,7 +204,7 @@ class _Algorithm:
     @property
     def pentapy_solver(self):
         """
-        The solver if using ``pentapy`` to solve banded equations.
+        The solver if using the dedicated pentadiagonal solvers to solve banded equations.
 
         .. deprecated:: 1.2
             The `pentapy_solver` property is deprecated and will be removed in

--- a/pybaselines/_algorithm_setup.py
+++ b/pybaselines/_algorithm_setup.py
@@ -183,9 +183,9 @@ class _Algorithm:
             raise ValueError('banded_solver must be an integer with a value in (1, 2, 3, 4)')
         self._banded_solver = solver
         if solver < 3:
-            self._pentapy_solver = solver
+            self._penta_solver = solver
         else:
-            self._pentapy_solver = 1  # default value
+            self._penta_solver = 2  # default value
 
     @property
     def pentapy_solver(self):
@@ -202,7 +202,7 @@ class _Algorithm:
              'version 1.4; use the `banded_solver` attribute instead'),
             DeprecationWarning, stacklevel=2
         )
-        return self._pentapy_solver
+        return self._penta_solver
 
     @pentapy_solver.setter
     def pentapy_solver(self, value):
@@ -434,11 +434,11 @@ class _Algorithm:
             weight_array = weight_array[self._sort_order]
 
         allow_lower = allow_lower and self.banded_solver < 4
-        allow_pentapy = self.banded_solver < 3
+        allow_penta = self.banded_solver < 3
 
         whittaker_system = PenalizedSystem(
-            self._size, lam, diff_order, allow_lower, reverse_diags, allow_pentapy=allow_pentapy,
-            pentapy_solver=self._pentapy_solver
+            self._size, lam, diff_order, allow_lower, reverse_diags, allow_penta=allow_penta,
+            penta_solver=self._penta_solver
         )
 
         return y, weight_array, whittaker_system

--- a/pybaselines/_banded_solvers.py
+++ b/pybaselines/_banded_solvers.py
@@ -49,10 +49,10 @@ def _ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
 
     Parameters
     ----------
-    lhs : numpy.ndarray, shape (5, N)
+    lhs : numpy.ndarray, shape (5, M)
         The pentadiagonal matrix `A` in LAPACK banded format banded format (see
         :func:`scipy.linalg.solve_banded`).
-    rhs : numpy.ndarray, shape (N,)
+    rhs : numpy.ndarray, shape (M,) or (M, N)
         The right-hand side of the equation.
     overwrite_ab : bool, optional
         Whether to overwrite `lhs` when solving. Default is False.
@@ -61,7 +61,7 @@ def _ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
 
     Returns
     -------
-    out : numpy.ndarray, shape (N,)
+    out : numpy.ndarray, shape (M,) or (M, N)
         The solution to the linear system, `x`.
     int
         If the matrix is singular, the returned integer is the row index plus one of where
@@ -97,7 +97,7 @@ def _ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     if overwrite_b:
         out = rhs
     else:
-        out = np.zeros(num_rows)
+        out = np.zeros(rhs.shape)
 
     # First row
     mu_i = lhs[2, 0]
@@ -213,10 +213,10 @@ def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
 
     Parameters
     ----------
-    lhs : numpy.ndarray, shape (5, N)
+    lhs : numpy.ndarray, shape (5, M)
         The pentadiagonal matrix `A` in LAPACK banded format banded format (see
         :func:`scipy.linalg.solve_banded`).
-    rhs : numpy.ndarray, shape (N,)
+    rhs : numpy.ndarray, shape (M,) or (M, N)
         The right-hand side of the equation.
     overwrite_ab : bool, optional
         Whether to overwrite `lhs` when solving. Default is False.
@@ -225,7 +225,7 @@ def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
 
     Returns
     -------
-    out : numpy.ndarray, shape (N,)
+    out : numpy.ndarray, shape (M,) or (M, N)
         The solution to the linear system, `x`.
     int
         If the matrix is singular, the returned integer is the row index plus one of where
@@ -261,7 +261,7 @@ def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     if overwrite_b:
         out = rhs
     else:
-        out = np.zeros(num_rows)
+        out = np.zeros(rhs.shape)
 
     # First row
     row = num_rows - 1
@@ -373,10 +373,10 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
 
     Parameters
     ----------
-    ab : numpy.ndarray, shape (5, N)
+    ab : numpy.ndarray, shape (5, M)
         The pentadiagonal matrix `A` in LAPACK banded format banded format (see
         :func:`scipy.linalg.solve_banded`).
-    b : numpy.ndarray, shape (N,)
+    b : numpy.ndarray, shape (M,) or (M, N)
         The right-hand side of the equation.
     solver : {1, 2}
         The solver to use. 1 designates the PTRANS-I algorithm from [1]_, and 2 designates
@@ -388,7 +388,7 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
 
     Returns
     -------
-    result : numpy.ndarray, shape (N,)
+    result : numpy.ndarray, shape (M,) or (M, N)
         The solution to the linear system, `x`.
 
     Raises

--- a/pybaselines/_banded_solvers.py
+++ b/pybaselines/_banded_solvers.py
@@ -947,7 +947,8 @@ def penta_factorize_solve(ab_factorization, b, solver=1, overwrite_b=False):
     ----------
     ab_factorization : array-like, shape (5, M)
         The factorization of the pentadiagonal matrix `A` in row-wise banded format (see
-        :func:`pentapy.solve`), as given by :func:`~.penta_factorize`.
+        https://geostat-framework.readthedocs.io/projects/pentapy/en/stable/examples/index.html`),
+        as given by :func:`~.penta_factorize`.
     b : array-like, shape (M,) or (M, N)
         The right-hand side of the equation.
     solver : {1, 2}, optional

--- a/pybaselines/_banded_solvers.py
+++ b/pybaselines/_banded_solvers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Dedicated solvers for pentadiagonal and heptadiagonal banded linear systems.
+"""Dedicated solvers for pentadiagonal banded linear systems.
 
 @author: Donald Erb
 Created on February 20, 2025
@@ -73,7 +73,10 @@ def _ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     following pentapy issue #11 and pentapy pull request #27 for faster indexing and better error
     handling.
 
-    Uses `lhs` in LAPACK banded format rather than the row-wise banded format used by pentapy.
+    Uses `lhs` in LAPACK banded format rather than the row-wise banded format used by ``pentapy``.
+    The additional indexing should require approximately ``4 * (N - 4) = 4N - 4`` additional
+    operations compared to using row-wise banded format, which theoretically requires
+    ``19N - 29`` operations. In practice, however, the additional time is negligible.
 
     References
     ----------
@@ -100,61 +103,61 @@ def _ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     mu_i = lhs[2, 0]
     if mu_i == 0.0:
         return out, 1
-    alpha_i_minus_1 = lhs[1, 1] / mu_i
-    beta_i_minus_1 = lhs[0, 2] / mu_i
-    z_i_minus_1 = rhs[0] / mu_i
-    alpha[0] = alpha_i_minus_1
-    beta[0] = beta_i_minus_1
-    out[0] = z_i_minus_1
+    alpha_i_minus_2 = lhs[1, 1] / mu_i
+    beta_i_minus_2 = lhs[0, 2] / mu_i
+    z_i_minus_2 = rhs[0] / mu_i
+    alpha[0] = alpha_i_minus_2
+    beta[0] = beta_i_minus_2
+    out[0] = z_i_minus_2
 
     # Second row
     gamma_i = lhs[3, 0]
-    mu_i = lhs[2, 1] - alpha_i_minus_1 * gamma_i
+    mu_i = lhs[2, 1] - alpha_i_minus_2 * gamma_i
     if mu_i == 0.0:
         return out, 2
-    alpha_i = (lhs[1, 2] - beta_i_minus_1 * gamma_i) / mu_i
-    alpha[1] = alpha_i
-    beta_i = lhs[0, 3] / mu_i
-    beta[1] = beta_i
-    z_i = (rhs[1] - z_i_minus_1 * gamma_i) / mu_i
-    out[1] = z_i
+    alpha_i_minus_1 = (lhs[1, 2] - beta_i_minus_2 * gamma_i) / mu_i
+    beta_i_minus_1 = lhs[0, 3] / mu_i
+    z_i_minus_1 = (rhs[1] - z_i_minus_2 * gamma_i) / mu_i
+    alpha[1] = alpha_i_minus_1
+    beta[1] = beta_i_minus_1
+    out[1] = z_i_minus_1
 
     # Central rows
     for i in range(2, num_rows - 2):
         e_i = lhs[4, i - 2]
-        gamma_i = lhs[3, i - 1] - alpha_i_minus_1 * e_i
-        mu_i = lhs[2, i] - beta_i_minus_1 * e_i - alpha_i * gamma_i
+        gamma_i = lhs[3, i - 1] - alpha_i_minus_2 * e_i
+        mu_i = lhs[2, i] - beta_i_minus_2 * e_i - alpha_i_minus_1 * gamma_i
         if mu_i == 0.0:
             return out, i + 1
 
-        alpha_i_plus_1 = (lhs[1, i + 1] - beta_i * gamma_i) / mu_i
-        alpha_i_minus_1 = alpha_i
-        alpha_i = alpha_i_plus_1
-        alpha[i] = alpha_i
+        alpha_i_minus_2 = alpha_i_minus_1
+        alpha_i_minus_1 = (lhs[1, i + 1] - beta_i_minus_1 * gamma_i) / mu_i
+        alpha[i] = alpha_i_minus_1
 
-        beta_i_plus_1 = lhs[0, i + 2] / mu_i
-        beta_i_minus_1 = beta_i
-        beta_i = beta_i_plus_1
-        beta[i] = beta_i
+        beta_i_minus_2 = beta_i_minus_1
+        beta_i_minus_1 = lhs[0, i + 2] / mu_i
+        beta[i] = beta_i_minus_1
 
-        z_i_plus_1 = (rhs[i] - z_i_minus_1 * e_i - z_i * gamma_i) / mu_i
+        z_i = (rhs[i] - z_i_minus_2 * e_i - z_i_minus_1 * gamma_i) / mu_i
+        z_i_minus_2 = z_i_minus_1
         z_i_minus_1 = z_i
-        z_i = z_i_plus_1
         out[i] = z_i
 
     # Second to last row
     row = num_rows - 2
     e_i = lhs[4, row - 2]
-    gamma_i = lhs[3, row - 1] - alpha_i_minus_1 * e_i
-    mu_i = lhs[2, row] - beta_i_minus_1 * e_i - alpha_i * gamma_i
+    gamma_i = lhs[3, row - 1] - alpha_i_minus_2 * e_i
+    mu_i = lhs[2, row] - beta_i_minus_2 * e_i - alpha_i_minus_1 * gamma_i
     if mu_i == 0.0:
         return out, num_rows - 1
 
-    alpha_i_plus_1 = (lhs[1, row + 1] - beta_i * gamma_i) / mu_i
+    alpha_i_minus_2 = alpha_i_minus_1
+    alpha_i_minus_1 = (lhs[1, row + 1] - beta_i_minus_1 * gamma_i) / mu_i
+    beta_i_minus_2 = beta_i_minus_1
     # Note that none of the below section is needed since only alpha[:num_rows - 2] and
     # beta[:num_rows - 2] is required for the backward substitution (would be needed if the
     # factorization was desired), but still compute it since it's cheap
-    alpha[row] = alpha_i_plus_1
+    alpha[row] = alpha_i_minus_1
     if overwrite_ab:
         # have to account for LAPACK format not having zeros in top right corner as compared
         # to row-wise banded format
@@ -162,28 +165,40 @@ def _ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
         alpha[row + 1:] = 0.0
     # End of unneeded section
 
-    z_i_plus_1 = (rhs[row] - z_i_minus_1 * e_i - z_i * gamma_i) / mu_i
-    z_i_minus_1 = z_i
-    z_i = z_i_plus_1
+    # Note: paper had a typo in Algorithm 1 saying
+    # z_{n-1} = (y_{n-1} - z_{n-2}*e_{n-1}-z_{n-2}*gamma_{n-1}) / mu_{n-1}
+    # when it should say
+    # z_{n-1} = (y_{n-1} - z_{n-3}*e_{n-1}-z_{n-2}*gamma_{n-1}) / mu_{n-1}
+    x_i_plus_1 = (rhs[row] - z_i_minus_2 * e_i - z_i_minus_1 * gamma_i) / mu_i
+    z_i_minus_2 = z_i_minus_1
+    z_i_minus_1 = x_i_plus_1
 
     # Last Row
     row = num_rows - 1
     e_i = lhs[4, row - 2]
-    gamma_i = lhs[3, row - 1] - alpha_i * e_i
-    mu_i = lhs[2, row] - beta_i * e_i - alpha_i_plus_1 * gamma_i
+    gamma_i = lhs[3, row - 1] - alpha_i_minus_2 * e_i
+    mu_i = lhs[2, row] - beta_i_minus_2 * e_i - alpha_i_minus_1 * gamma_i
     if mu_i == 0.0:
         return out, num_rows
 
-    # Backward substitution
-    z_i_plus_1 = (rhs[row] - z_i_minus_1 * e_i - z_i * gamma_i) / mu_i
-    z_i -= alpha_i_plus_1 * z_i_plus_1
-    out[row] = z_i_plus_1
-    out[num_rows - 2] = z_i
+    x_i_plus_2 = (rhs[row] - z_i_minus_2 * e_i - z_i_minus_1 * gamma_i) / mu_i
 
+    # Backward substitution
+    # Note: paper had a typo in Algorithm 1 saying
+    # z_{n} = (y_{n} - z_{n-1}*e_{n}-z_{n-1}*gamma_{n}) / mu_{n}
+    # when it should say
+    # z_{n} = (y_{n} - z_{n-2}*e_{n}-z_{n-1}*gamma_{n}) / mu_{n}
+    x_i_plus_1 -= alpha_i_minus_1 * x_i_plus_2
+    out[row] = x_i_plus_2
+    out[row - 1] = x_i_plus_1
     for i in range(num_rows - 3, -1, -1):
-        out[i] -= alpha[i] * z_i + beta[i] * z_i_plus_1
-        z_i_plus_1 = z_i
-        z_i = out[i]
+        # cannot do out[i] -= alpha[i] * x_i_plus_1 + beta[i] * x_i_plus_2 since Numba does not
+        # handle in-place operators on numpy arrays correctly (see
+        # https://github.com/numba/numba/issues/2644)
+        x_i = out[i] - alpha[i] * x_i_plus_1 - beta[i] * x_i_plus_2
+        x_i_plus_2 = x_i_plus_1
+        x_i_plus_1 = x_i
+        out[i] = x_i
 
     return out, 0
 
@@ -222,7 +237,10 @@ def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     following pentapy issue #11 and pentapy pull request #27 for faster indexing and better error
     handling.
 
-    Uses `lhs` in LAPACK banded format rather than the row-wise banded format used by pentapy.
+    Uses `lhs` in LAPACK banded format rather than the row-wise banded format used by ``pentapy``.
+    The additional indexing should require approximately ``4 * (N - 4) = 4N - 4`` additional
+    operations compared to using row-wise banded format, which theoretically requires
+    ``19N - 29`` operations. In practice, however, the additional time is negligible.
 
     References
     ----------
@@ -251,71 +269,69 @@ def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     if psi_i == 0.0:
         return out, num_rows
 
-    sigma_i_plus_1 = lhs[3, row - 1] / psi_i
+    sigma_i_plus_2 = lhs[3, row - 1] / psi_i
+    phi_i_plus_2 = lhs[4, row - 2] / psi_i
+    w_i_plus_2 = rhs[row] / psi_i
+
+    sigma[row] = sigma_i_plus_2
+    phi[row] = phi_i_plus_2
+    out[row] = w_i_plus_2
+
+    # Second row
+    row = num_rows - 2
+    rho_i = lhs[1, row + 1]
+    psi_i = lhs[2, row] - sigma_i_plus_2 * rho_i
+    if psi_i == 0.0:
+        return out, num_rows - 1
+
+    sigma_i_plus_1 = (lhs[3, row - 1] - phi_i_plus_2 * rho_i) / psi_i
     phi_i_plus_1 = lhs[4, row - 2] / psi_i
-    w_i_plus_1 = rhs[row] / psi_i
+    w_i_plus_1 = (rhs[row] - w_i_plus_2 * rho_i) / psi_i
 
     sigma[row] = sigma_i_plus_1
     phi[row] = phi_i_plus_1
     out[row] = w_i_plus_1
 
-    # Second row
-    row = num_rows - 2
-    rho_i = lhs[1, row + 1]
-    psi_i = lhs[2, row] - sigma_i_plus_1 * rho_i
-    if psi_i == 0.0:
-        return out, num_rows - 1
-
-    sigma_i = (lhs[3, row - 1] - phi_i_plus_1 * rho_i) / psi_i
-    phi_i = lhs[4, row - 2] / psi_i
-    w_i = (rhs[row] - w_i_plus_1 * rho_i) / psi_i
-
-    sigma[row] = sigma_i
-    phi[row] = phi_i
-    out[row] = w_i
-
     # Central rows
     for i in range(num_rows - 3, 1, -1):
         b_i = lhs[0, i + 2]
-        rho_i = lhs[1, i + 1] - sigma_i_plus_1 * b_i
-        psi_i = lhs[2, i] - phi_i_plus_1 * b_i - sigma_i * rho_i
+        rho_i = lhs[1, i + 1] - sigma_i_plus_2 * b_i
+        psi_i = lhs[2, i] - phi_i_plus_2 * b_i - sigma_i_plus_1 * rho_i
         if psi_i == 0.0:
             return out, i + 1
 
-        sigma_i_minus_1 = (lhs[3, i - 1] - phi_i * rho_i) / psi_i
-        sigma_i_plus_1 = sigma_i
-        sigma_i = sigma_i_minus_1
-        phi_i_minus_1 = lhs[4, i - 2] / psi_i
-        phi_i_plus_1 = phi_i
-        phi_i = phi_i_minus_1
+        sigma_i_plus_2 = sigma_i_plus_1
+        sigma_i_plus_1 = (lhs[3, i - 1] - phi_i_plus_1 * rho_i) / psi_i
+        sigma[i] = sigma_i_plus_1
 
-        w_i_minus_1 = (rhs[i] - w_i_plus_1 * b_i - w_i * rho_i) / psi_i
+        phi_i_plus_2 = phi_i_plus_1
+        phi_i_plus_1 = lhs[4, i - 2] / psi_i
+        phi[i] = phi_i_plus_1
+
+        w_i = (rhs[i] - w_i_plus_2 * b_i - w_i_plus_1 * rho_i) / psi_i
+        w_i_plus_2 = w_i_plus_1
         w_i_plus_1 = w_i
-        w_i = w_i_minus_1
-
-        sigma[i] = sigma_i
-        phi[i] = phi_i
         out[i] = w_i
 
     # Second to last row
     b_i = lhs[0, 3]
-    rho_i = lhs[1, 2] - sigma_i_plus_1 * b_i
-    psi_i = lhs[2, 1] - phi_i_plus_1 * b_i - sigma_i * rho_i
+    rho_i = lhs[1, 2] - sigma_i_plus_2 * b_i
+    psi_i = lhs[2, 1] - phi_i_plus_2 * b_i - sigma_i_plus_1 * rho_i
     if psi_i == 0.0:
         return out, 2
 
-    sigma_i_minus_1 = (lhs[3, 0] - phi_i * rho_i) / psi_i
-    sigma_i_plus_1 = sigma_i
-    sigma_i = sigma_i_minus_1
+    sigma_i_plus_2 = sigma_i_plus_1
+    sigma_i_plus_1 = (lhs[3, 0] - phi_i_plus_1 * rho_i) / psi_i
+    phi_i_plus_2 = phi_i_plus_1
 
-    w_i_minus_1 = (rhs[1] - w_i_plus_1 * b_i - w_i * rho_i) / psi_i
-    w_i_plus_1 = w_i
-    w_i = w_i_minus_1
+    x_i_minus_1 = (rhs[1] - w_i_plus_2 * b_i - w_i_plus_1 * rho_i) / psi_i
+    w_i_plus_2 = w_i_plus_1
+    w_i_plus_1 = x_i_minus_1
 
     # Note that none of the below section is needed since only sigma[2:] and phi[2:] is required
     # for the forward substitution (would be needed if the factorization was desired), but still
     # compute it since it's cheap
-    sigma[1] = sigma_i
+    sigma[1] = sigma_i_plus_1
     if overwrite_ab:
         # have to account for LAPACK format not having zeros in bottom left corner as compared
         # to row-wise banded format
@@ -325,23 +341,26 @@ def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
 
     # Last row
     b_i = lhs[0, 2]
-    rho_i = lhs[1, 1] - sigma_i_plus_1 * b_i
-    psi_i = lhs[2, 0] - phi_i * b_i - sigma_i * rho_i
+    rho_i = lhs[1, 1] - sigma_i_plus_2 * b_i
+    psi_i = lhs[2, 0] - phi_i_plus_2 * b_i - sigma_i_plus_1 * rho_i
     if psi_i == 0.0:
         return out, 1
 
-    w_i_minus_1 = (rhs[0] - w_i_plus_1 * b_i - w_i * rho_i) / psi_i
-    out[0] = w_i_minus_1
+    x_i_minus_2 = (rhs[0] - w_i_plus_2 * b_i - w_i_plus_1 * rho_i) / psi_i
 
     # Forward substitution
-    w_i -= sigma_i * w_i_minus_1
-    out[1] = w_i
+    x_i_minus_1 -= sigma_i_plus_1 * x_i_minus_2
+    out[0] = x_i_minus_2
+    out[1] = x_i_minus_1
     w_i_plus_1 = out[2]
     for i in range(2, num_rows):
-        # note that the phi[i] * w_i_minus_1 is added so that -= applies subtraction
-        out[i] -= sigma[i] * w_i + phi[i] * w_i_minus_1
-        w_i_minus_1 = w_i
-        w_i = out[i]
+        # cannot do out[i] -= sigma[i] * x_i_minus_1 + phi[i] * x_i_minus_2 since Numba does not
+        # handle in-place operators on numpy arrays correctly (see
+        # https://github.com/numba/numba/issues/2644)
+        x_i = out[i] - sigma[i] * x_i_minus_1 - phi[i] * x_i_minus_2
+        x_i_minus_2 = x_i_minus_1
+        x_i_minus_1 = x_i
+        out[i] = x_i
 
     return out, 0
 
@@ -388,7 +407,8 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
     lhs = np.asarray(ab, dtype=float)
     rhs = np.asarray(b, dtype=float)
     # TODO look at how scipy handles overwrite_[ab][b] for when np.asarray already copies
-    # the data
+    # the data -> does it matter? Both lhs and rhs are made internally and already floats
+    # so copies will never be made and the overwrites will always match their input
     rows, columns = ab.shape
     if rows != 5:
         raise ValueError('ab matrix must have 5 rows')
@@ -405,4 +425,3 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
         raise np.linalg.LinAlgError(f'Matrix is singular at row index {info - 1}')
 
     return result
-

--- a/pybaselines/_banded_solvers.py
+++ b/pybaselines/_banded_solvers.py
@@ -863,7 +863,7 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
     # so copies will never be made and the overwrites will always match their input
     rows, columns = ab.shape
     if rows != 5:
-        raise ValueError('ab matrix must have 5 rows')
+        raise ValueError(f'ab matrix must have 5 rows, instead had {rows} rows')
     elif solver not in (1, 2):
         raise ValueError(f'solver must be 1 or 2, but instead was {solver}')
     elif columns < 4:
@@ -920,12 +920,14 @@ def penta_factorize(ab, solver=1, overwrite_ab=False):
     lhs = np.asarray(ab, dtype=float)
     rows, columns = ab.shape
     if rows != 5:
-        raise ValueError('ab matrix must have 5 rows')
+        raise ValueError(f'ab matrix must have 5 rows, instead had {rows} rows')
     elif solver not in (1, 2):
         raise ValueError(f'solver must be 1 or 2, but instead was {solver}')
     elif columns < 4:
         # not worth doing by hand, should never come up in the context of baseline correction
-        raise ValueError('penta_factorize requires at least 4 columns to create the factorization')
+        raise ValueError(
+            f'penta_factorize requires at least 4 columns, instead had {columns} columns'
+        )
 
     func = {1: _ptrans_1_factorize, 2: _ptrans_2_factorize}[solver]
     factorization, info = func(lhs, overwrite_ab)
@@ -977,12 +979,14 @@ def penta_factorize_solve(ab_factorization, b, solver=1, overwrite_b=False):
     rhs = np.asarray(b, dtype=float)
     rows, columns = ab_factorization.shape
     if rows != 5:
-        raise ValueError('ab_factorization matrix must have 5 rows')
+        raise ValueError(f'ab_factorization matrix must have 5 rows, instead had {rows} rows')
     elif solver not in (1, 2):
         raise ValueError(f'solver must be 1 or 2, but instead was {solver}')
     elif columns < 4:
         # cannot support since penta_factorize does not allow
-        raise ValueError('penta_factorize_solve requires at least 4 columns')
+        raise ValueError(
+            f'penta_factorize_solve requires at least 4 columns, instead had {columns} columns'
+        )
     elif columns != rhs.shape[0]:
         raise ValueError(
             f'shape mismatch between ab_factorization and b, {ab_factorization.shape} vs {b.shape}'

--- a/pybaselines/_banded_solvers.py
+++ b/pybaselines/_banded_solvers.py
@@ -5,8 +5,8 @@
 Created on February 20, 2025
 
 
-The functions `ptrans1` and `ptrans2` were adapted from `pentapy`
-(https://github.com/GeoStat-Framework/pentapy) (last accessed March 25, 2025), which was
+All related `ptrans1` and `ptrans2` functions were adapted from `pentapy`
+(https://github.com/GeoStat-Framework/pentapy) (last accessed September 26, 2025), which was
 licensed under the MIT license below.
 
 The MIT License (MIT)
@@ -205,6 +205,233 @@ def _ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
 
 # adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
 @jit(nopython=True, cache=True)
+def _ptrans_1_factorize(lhs, overwrite_ab=False):
+    """
+    Factorizes a banded pentadiagonal matrix and store in row-wise banded format.
+
+    Parameters
+    ----------
+    lhs : numpy.ndarray, shape (5, N)
+        The pentadiagonal matrix `A` in LAPACK banded format banded format (see
+        :func:`scipy.linalg.solve_banded`).
+    overwrite_ab : bool, optional
+        Whether to overwrite `lhs` when solving. Default is False.
+
+    Returns
+    -------
+    factorization : numpy.ndarray, shape (5, N)
+        The factorization of `lhs`, stored in row-wise banded format.
+    int
+        If the matrix is singular, the returned integer is the row index plus one of where
+        the singularity occurred. Otherwise, returns 0.
+
+    Notes
+    -----
+    Derived from ``pentapy`` (https://github.com/GeoStat-Framework/pentapy), with modifications
+    following pentapy issue #11 and pentapy pull request #27 for faster indexing and better error
+    handling.
+
+    Uses `lhs` in LAPACK banded format rather than the row-wise banded format used by ``pentapy``.
+    The additional indexing should require approximately ``2N`` additional
+    operations compared to using row-wise banded format, which theoretically requires
+    ``19N - 29`` operations. In practice, however, the additional time is negligible.
+
+    References
+    ----------
+    Askar, S., et al. On Solving Pentadiagonal Linear Systems via Transformations. Mathematical
+    Problems in Engineering, 2015, 232456.
+
+    """
+    num_rows = lhs.shape[1]
+    if overwrite_ab:
+        # beta, alpha, and mu rows in the factorization correspond to lhs[0] lhs[1] and lhs[2],
+        # respectively; when lhs is in LAPACK format, their values are referenced before those
+        # locations are set, so can safely fill with the beta, alpha, and mu values; gamma and e
+        # must be tracked before setting their values within the factorization since they are set
+        # before reading
+        factorization = lhs
+    else:
+        factorization = np.zeros((5, num_rows))
+    beta = factorization[0]
+    alpha = factorization[1]
+    mu = factorization[2]
+    gamma = factorization[3]
+    e = factorization[4]
+
+    # First row
+    mu_i = lhs[2, 0]
+    if mu_i == 0.0:
+        return factorization, 1
+    alpha_i_minus_2 = lhs[1, 1] / mu_i
+    beta_i_minus_2 = lhs[0, 2] / mu_i
+    e_i = lhs[4, 0]
+    gamma_i = lhs[3, 0]
+    alpha[0] = alpha_i_minus_2
+    beta[0] = beta_i_minus_2
+    mu[0] = mu_i
+
+    # Second row
+    mu_i = lhs[2, 1] - alpha_i_minus_2 * gamma_i
+    if mu_i == 0.0:
+        return factorization, 2
+    alpha_i_minus_1 = (lhs[1, 2] - beta_i_minus_2 * gamma_i) / mu_i
+    beta_i_minus_1 = lhs[0, 3] / mu_i
+    e_i_plus_1 = lhs[4, 1]
+    c_i = lhs[3, 1]
+    alpha[1] = alpha_i_minus_1
+    beta[1] = beta_i_minus_1
+    mu[1] = mu_i
+    gamma[1] = gamma_i
+
+    # Central rows
+    for i in range(2, num_rows - 2):
+        gamma_i = c_i - alpha_i_minus_2 * e_i
+        mu_i = lhs[2, i] - beta_i_minus_2 * e_i - alpha_i_minus_1 * gamma_i
+        if mu_i == 0.0:
+            return factorization, i + 1
+
+        alpha_i_minus_2 = alpha_i_minus_1
+        alpha_i_minus_1 = (lhs[1, i + 1] - beta_i_minus_1 * gamma_i) / mu_i
+        alpha[i] = alpha_i_minus_1
+
+        beta_i_minus_2 = beta_i_minus_1
+        beta_i_minus_1 = lhs[0, i + 2] / mu_i
+        beta[i] = beta_i_minus_1
+
+        mu[i] = mu_i
+
+        c_i = lhs[3, i]
+        gamma[i] = gamma_i
+
+        e_i_plus_2 = lhs[4, i]
+        e[i] = e_i
+        e_i = e_i_plus_1
+        e_i_plus_1 = e_i_plus_2
+
+    # Second to last row
+    row = num_rows - 2
+    gamma_i = c_i - alpha_i_minus_2 * e_i
+    mu_i = lhs[2, row] - beta_i_minus_2 * e_i - alpha_i_minus_1 * gamma_i
+    if mu_i == 0.0:
+        return factorization, num_rows - 1
+
+    alpha_i_minus_2 = alpha_i_minus_1
+    alpha_i_minus_1 = (lhs[1, row + 1] - beta_i_minus_1 * gamma_i) / mu_i
+    beta_i_minus_2 = beta_i_minus_1
+    alpha[row] = alpha_i_minus_1
+    mu[row] = mu_i
+    c_i = lhs[3, row]
+    gamma[row] = gamma_i
+    e[row] = e_i
+    e_i = e_i_plus_1
+
+    # Last Row
+    row = num_rows - 1
+    gamma_i = c_i - alpha_i_minus_2 * e_i
+    mu_i = lhs[2, row] - beta_i_minus_2 * e_i - alpha_i_minus_1 * gamma_i
+    if mu_i == 0.0:
+        return factorization, num_rows
+    mu[row] = mu_i
+    gamma[row] = gamma_i
+    e[row] = e_i
+
+    if overwrite_ab:
+        # have to account for LAPACK format not having zeros in top-right and bottom-left
+        # corners as compared to row-wise banded format
+        beta[-2:] = 0.0
+        alpha[-1] = 0.0
+        gamma[0] = 0.0
+        e[:2] = 0.0
+
+    return factorization, 0
+
+
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
+def _ptrans_1_factorize_solve(factorization, rhs, overwrite_b=False):
+    """
+    Pentadiagonal banded matrix solver using transformations and backward substitution.
+
+    Solves the equation ``A @ x = rhs``, given the factorization of the banded matrix `A`.
+
+    Parameters
+    ----------
+    factorization : numpy.ndarray, shape (5, M)
+        The factorization of `A`, stored in row-wise banded format.
+    rhs : numpy.ndarray, shape (M,) or (M, N)
+        The right-hand side of the equation.
+    overwrite_b : bool, optional
+        Whether to overwrite `rhs` when solving. Default is False.
+
+    Returns
+    -------
+    out : numpy.ndarray, shape (M,) or (M, N)
+        The solution to the linear system, `x`.
+
+    """
+    num_rows = factorization.shape[1]
+    if overwrite_b:
+        out = rhs
+    else:
+        out = np.zeros(rhs.shape)
+
+    beta = factorization[0]
+    alpha = factorization[1]
+    mu = factorization[2]
+    gamma = factorization[3]
+    e = factorization[4]
+
+    # First row
+    z_i_minus_2 = rhs[0] / mu[0]
+    out[0] = z_i_minus_2
+
+    # Second row
+    z_i_minus_1 = (rhs[1] - z_i_minus_2 * gamma[1]) / mu[1]
+    out[1] = z_i_minus_1
+
+    # Central rows
+    for i in range(2, num_rows - 2):
+        z_i = (rhs[i] - z_i_minus_2 * e[i] - z_i_minus_1 * gamma[i]) / mu[i]
+        z_i_minus_2 = z_i_minus_1
+        z_i_minus_1 = z_i
+        out[i] = z_i
+
+    # Second to last row
+    row = num_rows - 2
+    # Note: paper had a typo in Algorithm 1 saying
+    # z_{n-1} = (y_{n-1} - z_{n-2}*e_{n-1}-z_{n-2}*gamma_{n-1}) / mu_{n-1}
+    # when it should say
+    # z_{n-1} = (y_{n-1} - z_{n-3}*e_{n-1}-z_{n-2}*gamma_{n-1}) / mu_{n-1}
+    x_i_plus_1 = (rhs[row] - z_i_minus_2 * e[row] - z_i_minus_1 * gamma[row]) / mu[row]
+    z_i_minus_2 = z_i_minus_1
+    z_i_minus_1 = x_i_plus_1
+
+    # Last Row
+    row = num_rows - 1
+    x_i_plus_2 = (rhs[row] - z_i_minus_2 * e[row] - z_i_minus_1 * gamma[row]) / mu[row]
+
+    # Backward substitution
+    # Note: paper had a typo in Algorithm 1 saying
+    # z_{n} = (y_{n} - z_{n-1}*e_{n}-z_{n-1}*gamma_{n}) / mu_{n}
+    # when it should say
+    # z_{n} = (y_{n} - z_{n-2}*e_{n}-z_{n-1}*gamma_{n}) / mu_{n}
+    x_i_plus_1 -= alpha[row - 1] * x_i_plus_2
+    out[row] = x_i_plus_2
+    out[row - 1] = x_i_plus_1
+    for i in range(num_rows - 3, -1, -1):
+        # cannot do out[i] -= alpha[i] * x_i_plus_1 + beta[i] * x_i_plus_2 since Numba does not
+        # handle in-place operators on numpy arrays correctly (see
+        # https://github.com/numba/numba/issues/2644)
+        x_i = out[i] - alpha[i] * x_i_plus_1 - beta[i] * x_i_plus_2
+        x_i_plus_2 = x_i_plus_1
+        x_i_plus_1 = x_i
+        out[i] = x_i
+
+    return out
+
+
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
 def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     """
     Pentadiagonal banded matrix solver using transformations and forward substitution.
@@ -365,6 +592,230 @@ def _ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
     return out, 0
 
 
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
+def _ptrans_2_factorize(lhs, overwrite_ab=False):
+    """
+    Factorizes a banded pentadiagonal matrix and store in row-wise banded format.
+
+    Parameters
+    ----------
+    lhs : numpy.ndarray, shape (5, N)
+        The pentadiagonal matrix `A` in LAPACK banded format banded format (see
+        :func:`scipy.linalg.solve_banded`).
+    overwrite_ab : bool, optional
+        Whether to overwrite `lhs` when solving. Default is False.
+
+    Returns
+    -------
+    factorization : numpy.ndarray, shape (5, N)
+        The factorization of `lhs`, stored in row-wise banded format.
+    int
+        If the matrix is singular, the returned integer is the row index plus one of where
+        the singularity occurred. Otherwise, returns 0.
+
+    Notes
+    -----
+    Derived from ``pentapy`` (https://github.com/GeoStat-Framework/pentapy), with modifications
+    following pentapy issue #11 and pentapy pull request #27 for faster indexing and better error
+    handling.
+
+    Uses `lhs` in LAPACK banded format rather than the row-wise banded format used by ``pentapy``.
+    The additional indexing should require approximately ``2N`` additional
+    operations compared to using row-wise banded format, which theoretically requires
+    ``19N - 29`` operations. In practice, however, the additional time is negligible.
+
+    References
+    ----------
+    Askar, S., et al. On Solving Pentadiagonal Linear Systems via Transformations. Mathematical
+    Problems in Engineering, 2015, 232456.
+
+    """
+    num_rows = lhs.shape[1]
+    if overwrite_ab:
+        # psi, sigma and phi rows in the factorization correspond to lhs[2] lhs[3] and lhs[4],
+        # respectively; when lhs is in LAPACK format, their values are referenced before those
+        # locations are set, so can safely fill with the psi, sigma, and phi values; rho and b
+        # must be tracked before setting their values within the factorization since they are set
+        # before reading
+        factorization = lhs
+    else:
+        factorization = np.zeros((5, num_rows))
+    b = factorization[0]
+    rho = factorization[1]
+    psi = factorization[2]
+    sigma = factorization[3]
+    phi = factorization[4]
+
+    # First row
+    row = num_rows - 1
+    psi_i = lhs[2, row]
+    if psi_i == 0.0:
+        return factorization, num_rows
+
+    sigma_i_plus_2 = lhs[3, row - 1] / psi_i
+    phi_i_plus_2 = lhs[4, row - 2] / psi_i
+    b_i = lhs[0, row]
+    rho_i = lhs[1, row]
+
+    sigma[row] = sigma_i_plus_2
+    phi[row] = phi_i_plus_2
+    psi[row] = psi_i
+
+    # Second row
+    row = num_rows - 2
+    psi_i = lhs[2, row] - sigma_i_plus_2 * rho_i
+    if psi_i == 0.0:
+        return factorization, num_rows - 1
+
+    sigma_i_plus_1 = (lhs[3, row - 1] - phi_i_plus_2 * rho_i) / psi_i
+    phi_i_plus_1 = lhs[4, row - 2] / psi_i
+    b_i_minus_1 = lhs[0, row]
+    a_i = lhs[1, row]
+
+    sigma[row] = sigma_i_plus_1
+    phi[row] = phi_i_plus_1
+    psi[row] = psi_i
+    rho[row] = rho_i
+
+    # Central rows
+    for i in range(num_rows - 3, 1, -1):
+        rho_i = a_i - sigma_i_plus_2 * b_i
+        psi_i = lhs[2, i] - phi_i_plus_2 * b_i - sigma_i_plus_1 * rho_i
+        if psi_i == 0.0:
+            return factorization, i + 1
+
+        sigma_i_plus_2 = sigma_i_plus_1
+        sigma_i_plus_1 = (lhs[3, i - 1] - phi_i_plus_1 * rho_i) / psi_i
+        sigma[i] = sigma_i_plus_1
+
+        phi_i_plus_2 = phi_i_plus_1
+        phi_i_plus_1 = lhs[4, i - 2] / psi_i
+        phi[i] = phi_i_plus_1
+
+        psi[i] = psi_i
+
+        a_i = lhs[1, i]
+        rho[i] = rho_i
+
+        b_i_minus_2 = lhs[0, i]
+        b[i] = b_i
+        b_i = b_i_minus_1
+        b_i_minus_1 = b_i_minus_2
+
+    # Second to last row
+    rho_i = a_i - sigma_i_plus_2 * b_i
+    psi_i = lhs[2, 1] - phi_i_plus_2 * b_i - sigma_i_plus_1 * rho_i
+    if psi_i == 0.0:
+        return factorization, 2
+
+    sigma_i_plus_2 = sigma_i_plus_1
+    sigma_i_plus_1 = (lhs[3, 0] - phi_i_plus_1 * rho_i) / psi_i
+    phi_i_plus_2 = phi_i_plus_1
+    sigma[1] = sigma_i_plus_1
+    psi[1] = psi_i
+    a_i = lhs[1, 1]
+    rho[1] = rho_i
+    b[1] = b_i
+    b_i = b_i_minus_1
+
+    # Last row
+    rho_i = a_i - sigma_i_plus_2 * b_i
+    psi_i = lhs[2, 0] - phi_i_plus_2 * b_i - sigma_i_plus_1 * rho_i
+    if psi_i == 0.0:
+        return factorization, 1
+    psi[0] = psi_i
+    rho[0] = rho_i
+    b[0] = b_i
+
+    if overwrite_ab:
+        # have to account for LAPACK format not having zeros in top-right and bottom-left
+        # corners as compared to row-wise banded format
+        sigma[0] = 0.0
+        phi[:2] = 0.0
+        b[-2:] = 0.0
+        rho[-1:] = 0.0
+
+    return factorization, 0
+
+
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
+def _ptrans_2_factorize_solve(factorization, rhs, overwrite_b=False):
+    """
+    Pentadiagonal banded matrix solver using transformations and forward substitution.
+
+    Solves the equation ``A @ x = rhs``, given the factorization of the banded matrix `A`.
+
+    Parameters
+    ----------
+    factorization : numpy.ndarray, shape (5, M)
+        The factorization of `A`, stored in row-wise banded format.
+    rhs : numpy.ndarray, shape (M,) or (M, N)
+        The right-hand side of the equation.
+    overwrite_b : bool, optional
+        Whether to overwrite `rhs` when solving. Default is False.
+
+    Returns
+    -------
+    out : numpy.ndarray, shape (M,) or (M, N)
+        The solution to the linear system, `x`.
+
+    """
+    num_rows = factorization.shape[1]
+    if overwrite_b:
+        out = rhs
+    else:
+        out = np.zeros(rhs.shape)
+
+    b = factorization[0]
+    rho = factorization[1]
+    psi = factorization[2]
+    sigma = factorization[3]
+    phi = factorization[4]
+
+    # First row
+    row = num_rows - 1
+    w_i_plus_2 = rhs[row] / psi[row]
+    out[row] = w_i_plus_2
+
+    # Second row
+    row = num_rows - 2
+    w_i_plus_1 = (rhs[row] - w_i_plus_2 * rho[row]) / psi[row]
+    out[row] = w_i_plus_1
+
+    # Central rows
+    for i in range(num_rows - 3, 1, -1):
+        w_i = (rhs[i] - w_i_plus_2 * b[i] - w_i_plus_1 * rho[i]) / psi[i]
+        w_i_plus_2 = w_i_plus_1
+        w_i_plus_1 = w_i
+        out[i] = w_i
+
+    # Second to last row
+    x_i_minus_1 = (rhs[1] - w_i_plus_2 * b[1] - w_i_plus_1 * rho[1]) / psi[1]
+    w_i_plus_2 = w_i_plus_1
+    w_i_plus_1 = x_i_minus_1
+
+    # Last row
+    x_i_minus_2 = (rhs[0] - w_i_plus_2 * b[0] - w_i_plus_1 * rho[0]) / psi[0]
+
+    # Forward substitution
+    x_i_minus_1 -= sigma[1] * x_i_minus_2
+    out[0] = x_i_minus_2
+    out[1] = x_i_minus_1
+    w_i_plus_1 = out[2]
+    for i in range(2, num_rows):
+        # cannot do out[i] -= sigma[i] * x_i_minus_1 + phi[i] * x_i_minus_2 since Numba does not
+        # handle in-place operators on numpy arrays correctly (see
+        # https://github.com/numba/numba/issues/2644)
+        x_i = out[i] - sigma[i] * x_i_minus_1 - phi[i] * x_i_minus_2
+        x_i_minus_2 = x_i_minus_1
+        x_i_minus_1 = x_i
+        out[i] = x_i
+
+    return out
+
+
 def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
     """
     Pentadiagonal banded matrix solver using transformations.
@@ -373,10 +824,10 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
 
     Parameters
     ----------
-    ab : numpy.ndarray, shape (5, M)
-        The pentadiagonal matrix `A` in LAPACK banded format banded format (see
+    ab : array-like, shape (5, M)
+        The pentadiagonal matrix `A` in LAPACK banded format (see
         :func:`scipy.linalg.solve_banded`).
-    b : numpy.ndarray, shape (M,) or (M, N)
+    b : array-like, shape (M,) or (M, N)
         The right-hand side of the equation.
     solver : {1, 2}, optional
         The solver to use. 1 (default) designates the PTRANS-I algorithm from [1]_, and 2
@@ -421,10 +872,123 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
             (2, 2), lhs, rhs, overwrite_ab=overwrite_ab, overwrite_b=overwrite_b,
             check_finite=False
         )
+    elif columns != rhs.shape[0]:
+        raise ValueError(f'shape mismatch between ab and b, {ab.shape} vs {b.shape}')
 
     func = {1: _ptrans_1, 2: _ptrans_2}[solver]
     result, info = func(lhs, rhs, overwrite_ab, overwrite_b)
     if info > 0:
         raise np.linalg.LinAlgError(f'Matrix is singular at row index {info - 1}')
+
+    return result
+
+
+def penta_factorize(ab, solver=1, overwrite_ab=False):
+    """
+    Factorizes a banded pentadiagonal matrix and store in row-wise banded format.
+
+    Parameters
+    ----------
+    ab : array-like, shape (5, M)
+        The pentadiagonal matrix `A` in LAPACK banded format (see
+        :func:`scipy.linalg.solve_banded`).
+    solver : {1, 2}, optional
+        The solver to use. 1 (default) designates the PTRANS-I algorithm from [1]_, and 2
+        designates the PTRANS-II algorithm from [1]_.
+    overwrite_ab : bool, optional
+        Whether to overwrite `ab` when solving. Default is False.
+
+    Returns
+    -------
+    factorization : numpy.ndarray, shape (5, M)
+        The factorization of `ab`, stored in row-wise banded format.
+
+    Raises
+    ------
+    ValueError
+        Raised if `ab` has less than 3 columns or if `ab` does not have 5 rows. Also
+        raised if `solver` is not 1 or 2.
+    numpy.linalg.LinAlgError
+        Raised if `ab` is singular.
+
+    References
+    ----------
+    .. [1] Askar, S., et al. On Solving Pentadiagonal Linear Systems via Transformations.
+           Mathematical Problems in Engineering, 2015, 232456.
+
+    """
+    lhs = np.asarray(ab, dtype=float)
+    rows, columns = ab.shape
+    if rows != 5:
+        raise ValueError('ab matrix must have 5 rows')
+    elif solver not in (1, 2):
+        raise ValueError(f'solver must be 1 or 2, but instead was {solver}')
+    elif columns < 4:
+        # not worth doing by hand, should never come up in the context of baseline correction
+        raise ValueError('penta_factorize requires at least 4 columns to create the factorization')
+
+    func = {1: _ptrans_1_factorize, 2: _ptrans_2_factorize}[solver]
+    factorization, info = func(lhs, overwrite_ab)
+    if info > 0:
+        raise np.linalg.LinAlgError(f'Matrix is singular at row index {info - 1}')
+
+    return factorization
+
+
+def penta_factorize_solve(ab_factorization, b, solver=1, overwrite_b=False):
+    """
+    Pentadiagonal banded matrix solver using transformations, given the factorization.
+
+    Solves the equation ``A @ x = rhs``, given the factorization of the banded matrix `A`.
+
+    Parameters
+    ----------
+    ab_factorization : array-like, shape (5, M)
+        The factorization of the pentadiagonal matrix `A` in row-wise banded format (see
+        :func:`pentapy.solve`), as given by :func:`~.penta_factorize`.
+    b : array-like, shape (M,) or (M, N)
+        The right-hand side of the equation.
+    solver : {1, 2}, optional
+        The solver to use. 1 (default) designates the PTRANS-I algorithm from [1]_, and 2
+        designates the PTRANS-II algorithm from [1]_.
+    overwrite_b : bool, optional
+        Whether to overwrite `b` when solving. Default is False.
+
+    Returns
+    -------
+    result : numpy.ndarray, shape (M,) or (M, N)
+        The solution to the linear system, `x`.
+
+    Raises
+    ------
+    ValueError
+        Raised if `ab` has less than 3 columns or if `ab` does not have 5 rows. Also
+        raised if `solver` is not 1 or 2.
+    numpy.linalg.LinAlgError
+        Raised if `ab` is singular.
+
+    References
+    ----------
+    .. [1] Askar, S., et al. On Solving Pentadiagonal Linear Systems via Transformations.
+           Mathematical Problems in Engineering, 2015, 232456.
+
+    """
+    lhs = np.asarray(ab_factorization, dtype=float)
+    rhs = np.asarray(b, dtype=float)
+    rows, columns = ab_factorization.shape
+    if rows != 5:
+        raise ValueError('ab_factorization matrix must have 5 rows')
+    elif solver not in (1, 2):
+        raise ValueError(f'solver must be 1 or 2, but instead was {solver}')
+    elif columns < 4:
+        # cannot support since penta_factorize does not allow
+        raise ValueError('penta_factorize_solve requires at least 4 columns')
+    elif columns != rhs.shape[0]:
+        raise ValueError(
+            f'shape mismatch between ab_factorization and b, {ab_factorization.shape} vs {b.shape}'
+        )
+
+    func = {1: _ptrans_1_factorize_solve, 2: _ptrans_2_factorize_solve}[solver]
+    result = func(lhs, rhs, overwrite_b)
 
     return result

--- a/pybaselines/_banded_solvers.py
+++ b/pybaselines/_banded_solvers.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+"""Dedicated solvers for pentadiagonal and heptadiagonal banded linear systems.
+
+@author: Donald Erb
+Created on February 20, 2025
+
+
+The functions `ptrans1` and `ptrans2` were adapted from `pentapy`
+(https://github.com/GeoStat-Framework/pentapy) (last accessed March 25, 2025), which was
+licensed under the MIT license below.
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Sebastian Müller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+import numpy as np
+
+from ._compat import jit
+
+
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
+def ptrans_1(lhs, rhs, overwrite_ab=False, overwrite_b=False):
+    """
+    Pentadiagonal banded matrix solver using transformations and backward substitution.
+
+    Solves the equation ``A @ x = rhs``, given `A` in row-wise banded format as `lhs`.
+
+    Parameters
+    ----------
+    lhs : numpy.ndarray, shape (5, N)
+        The pentadiagonal matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+    rhs : numpy.ndarray, shape (N,)
+        The right-hand side of the equation.
+    overwrite_ab : bool, optional
+        Whether to overwrite `lhs` when solving. Default is False.
+    overwrite_b : bool, optional
+        Whether to overwrite `rhs` when solving. Default is False.
+
+    Returns
+    -------
+    out : numpy.ndarray, shape (N,)
+        The solution to the linear system, `x`.
+    int
+        If the matrix is singular, the returned integer is the row index plus one of where
+        the singularity occurred. Otherwise, returns 0.
+
+    Notes
+    -----
+    Derived from ``pentapy`` (https://github.com/GeoStat-Framework/pentapy), with modifications
+    following pentapy issue #11 and pentapy pull request #27 for faster indexing and better error
+    handling.
+
+    References
+    ----------
+    Askar, S., et al. On Solving Pentadiagonal Linear Systems via Transformations. Mathematical
+    Problems in Engineering, 2015, 232456.
+
+    """
+    num_rows = lhs.shape[1]
+    if overwrite_ab:
+        # alpha and beta rows in the factorization correspond to lhs[1] and lhs[0], respectively,
+        # so the location of expected zeros will be the same when using lhs[1] and lhs[0] -> no need
+        # to make new zero arrays
+        alpha = lhs[1]
+        beta = lhs[0]
+    else:
+        alpha = np.zeros(num_rows)
+        beta = np.zeros(num_rows)
+    if overwrite_b:
+        out = rhs
+    else:
+        out = np.zeros(num_rows)
+
+    # First row
+    mu_i = lhs[2, 0]
+    if mu_i == 0.0:
+        return out, 1
+    alpha_i_minus_1 = lhs[1, 0] / mu_i
+    beta_i_minus_1 = lhs[0, 0] / mu_i
+    z_i_minus_1 = rhs[0] / mu_i
+    alpha[0] = alpha_i_minus_1
+    beta[0] = beta_i_minus_1
+    out[0] = z_i_minus_1
+
+    # Second row
+    gamma_i = lhs[3, 1]
+    mu_i = lhs[2, 1] - alpha_i_minus_1 * gamma_i
+    if mu_i == 0.0:
+        return out, 2
+    alpha_i = (lhs[1, 1] - beta_i_minus_1 * gamma_i) / mu_i
+    alpha[1] = alpha_i
+    beta_i = lhs[0, 1] / mu_i
+    beta[1] = beta_i
+    z_i = (rhs[1] - z_i_minus_1 * gamma_i) / mu_i
+    out[1] = z_i
+
+    # Central rows
+    for i in range(2, num_rows - 2):
+        e_i = lhs[4, i]
+        gamma_i = lhs[3, i] - alpha_i_minus_1 * e_i
+        mu_i = lhs[2, i] - beta_i_minus_1 * e_i - alpha_i * gamma_i
+        if mu_i == 0.0:
+            return out, i + 1
+
+        alpha_i_plus_1 = (lhs[1, i] - beta_i * gamma_i) / mu_i
+        alpha_i_minus_1 = alpha_i
+        alpha_i = alpha_i_plus_1
+        alpha[i] = alpha_i
+
+        beta_i_plus_1 = lhs[0, i] / mu_i
+        beta_i_minus_1 = beta_i
+        beta_i = beta_i_plus_1
+        beta[i] = beta_i
+
+        z_i_plus_1 = (rhs[i] - z_i_minus_1 * e_i - z_i * gamma_i) / mu_i
+        z_i_minus_1 = z_i
+        z_i = z_i_plus_1
+        out[i] = z_i
+
+    # Second to last row
+    row = num_rows - 2
+    e_i = lhs[4, row]
+    gamma_i = lhs[3, row] - alpha_i_minus_1 * e_i
+    mu_i = lhs[2, row] - beta_i_minus_1 * e_i - alpha_i * gamma_i
+    if mu_i == 0.0:
+        return out, num_rows - 1
+
+    alpha_i_plus_1 = (lhs[1, row] - beta_i * gamma_i) / mu_i
+    alpha[row] = alpha_i_plus_1
+
+    z_i_plus_1 = (rhs[row] - z_i_minus_1 * e_i - z_i * gamma_i) / mu_i
+    z_i_minus_1 = z_i
+    z_i = z_i_plus_1
+    out[row] = z_i_plus_1
+
+    # Last Row
+    row = num_rows - 1
+    e_i = lhs[4, row]
+    gamma_i = lhs[3, row] - alpha_i * e_i
+    mu_i = lhs[2, row] - beta_i * e_i - alpha_i_plus_1 * gamma_i
+    if mu_i == 0.0:
+        return out, num_rows
+
+    # Backward substitution that overwrites z with the result
+    z_i_plus_1 = (rhs[row] - z_i_minus_1 * e_i - z_i * gamma_i) / mu_i
+    z_i -= alpha_i_plus_1 * z_i_plus_1
+    out[row] = z_i_plus_1
+    out[num_rows - 2] = z_i
+
+    for i in range(num_rows - 3, -1, -1):
+        out[i] -= alpha[i] * z_i + beta[i] * z_i_plus_1
+        z_i_plus_1 = z_i
+        z_i = out[i]
+
+    return out, 0
+
+
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
+def ptrans_2(lhs, rhs, overwrite_ab=False, overwrite_b=False):
+    """
+    Pentadiagonal banded matrix solver using transformations and forward substitution.
+
+    Solves the equation ``A @ x = rhs``, given `A` in row-wise banded format as `lhs`.
+
+    Parameters
+    ----------
+    lhs : numpy.ndarray, shape (5, N)
+        The pentadiagonal matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+    rhs : numpy.ndarray, shape (N,)
+        The right-hand side of the equation.
+    overwrite_ab : bool, optional
+        Whether to overwrite `lhs` when solving. Default is False.
+    overwrite_b : bool, optional
+        Whether to overwrite `rhs` when solving. Default is False.
+
+    Returns
+    -------
+    out : numpy.ndarray, shape (N,)
+        The solution to the linear system, `x`.
+    int
+        If the matrix is singular, the returned integer is the row index plus one of where
+        the singularity occurred. Otherwise, returns 0.
+
+    Notes
+    -----
+    Derived from ``pentapy`` (https://github.com/GeoStat-Framework/pentapy), with modifications
+    following pentapy issue #11 and pentapy pull request #27 for faster indexing and better error
+    handling.
+
+    References
+    ----------
+    Askar, S., et al. On Solving Pentadiagonal Linear Systems via Transformations. Mathematical
+    Problems in Engineering, 2015, 232456.
+
+    """
+    num_rows = lhs.shape[1]
+    if overwrite_ab:
+        # sigma and phi rows in the factorization correspond to lhs[3] and lhs[4], respectively,
+        # so the location of expected zeros will be the same when using lhs[1] and lhs[0] -> no need
+        # to make new zero arrays
+        sigma = lhs[3]
+        phi = lhs[4]
+    else:
+        sigma = np.zeros(num_rows)
+        phi = np.zeros(num_rows)
+    if overwrite_b:
+        out = rhs
+    else:
+        out = np.zeros(num_rows)
+
+    # First row
+    row = num_rows - 1
+    psi_i = lhs[2, row]
+    if psi_i == 0.0:
+        return out, num_rows
+
+    sigma_i_plus_1 = lhs[3, row] / psi_i
+    phi_i_plus_1 = lhs[4, row] / psi_i
+    w_i_plus_1 = rhs[row] / psi_i
+
+    sigma[row] = sigma_i_plus_1
+    phi[row] = phi_i_plus_1
+    out[row] = w_i_plus_1
+
+    # Second row
+    row = num_rows - 2
+    rho_i = lhs[1, row]
+    psi_i = lhs[2, row] - sigma_i_plus_1 * rho_i
+    if psi_i == 0.0:
+        return out, num_rows - 1
+
+    sigma_i = (lhs[3, row] - phi_i_plus_1 * rho_i) / psi_i
+    phi_i = lhs[4, row] / psi_i
+    w_i = (rhs[row] - w_i_plus_1 * rho_i) / psi_i
+
+    sigma[row] = sigma_i
+    phi[row] = phi_i
+    out[row] = w_i
+
+    # Central rows
+    for i in range(num_rows - 3, 1, -1):
+        b_i = lhs[0, i]
+        rho_i = lhs[1, i] - sigma_i_plus_1 * b_i
+        psi_i = lhs[2, i] - phi_i_plus_1 * b_i - sigma_i * rho_i
+        if psi_i == 0.0:
+            return out, i + 1
+
+        sigma_i_minus_1 = (lhs[3, i] - phi_i * rho_i) / psi_i
+        sigma_i_plus_1 = sigma_i
+        sigma_i = sigma_i_minus_1
+        phi_i_minus_1 = lhs[4, i] / psi_i
+        phi_i_plus_1 = phi_i
+        phi_i = phi_i_minus_1
+
+        w_i_minus_1 = (rhs[i] - w_i_plus_1 * b_i - w_i * rho_i) / psi_i
+        w_i_plus_1 = w_i
+        w_i = w_i_minus_1
+
+        sigma[i] = sigma_i
+        phi[i] = phi_i
+        out[i] = w_i
+
+    # Second to last row
+    b_i = lhs[0, 1]
+    rho_i = lhs[1, 1] - sigma_i_plus_1 * b_i
+    psi_i = lhs[2, 1] - phi_i_plus_1 * b_i - sigma_i * rho_i
+    if psi_i == 0.0:
+        return out, 2
+
+    sigma_i_minus_1 = (lhs[3, 1] - phi_i * rho_i) / psi_i
+    sigma_i_plus_1 = sigma_i
+    sigma_i = sigma_i_minus_1
+
+    w_i_minus_1 = (rhs[1] - w_i_plus_1 * b_i - w_i * rho_i) / psi_i
+    w_i_plus_1 = w_i
+    w_i = w_i_minus_1
+
+    sigma[1] = sigma_i
+    out[1] = w_i
+
+    # Last row
+    b_i = lhs[0, 0]
+    rho_i = lhs[1, 0] - sigma_i_plus_1 * b_i
+    psi_i = lhs[2, 0] - phi_i * b_i - sigma_i * rho_i
+    if psi_i == 0.0:
+        return out, 1
+
+    w_i_minus_1 = (rhs[0] - w_i_plus_1 * b_i - w_i * rho_i) / psi_i
+    out[0] = w_i_minus_1
+
+    # Foreward substitution
+    w_i -= sigma_i * w_i_minus_1
+    out[1] = w_i
+    w_i_plus_1 = out[2]
+    for i in range(2, num_rows):
+        # note that the phi[i] * w_i_minus_1 is added so that -= applies subtraction
+        out[i] -= sigma[i] * w_i + phi[i] * w_i_minus_1
+        w_i_minus_1 = w_i
+        w_i = out[i]
+
+    return out, 0
+
+
+def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
+    """
+    Pentadiagonal banded matrix solver using transformations.
+
+    Solves the equation ``A @ x = rhs``, given `A` in row-wise banded format as `lhs`.
+
+    Parameters
+    ----------
+    ab : numpy.ndarray, shape (5, N)
+        The pentadiagonal matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+    b : numpy.ndarray, shape (N,)
+        The right-hand side of the equation.
+    solver : {1, 2}
+        The solver to use. 1 designates the PTRANS-I algorithm from [1]_, and 2 designates
+        the PTRANS-II algorithm from [1]_.
+    overwrite_ab : bool, optional
+        Whether to overwrite `ab` when solving. Default is False.
+    overwrite_b : bool, optional
+        Whether to overwrite `b` when solving. Default is False.
+
+    Returns
+    -------
+    result : numpy.ndarray, shape (N,)
+        The solution to the linear system, `x`.
+
+    Raises
+    ------
+    ValueError
+        Raised if `ab` has less than 3 columns or if `ab` does not have 5 rows.
+    numpy.linalg.LinAlgError
+        Raised if `ab` is singular.
+
+    References
+    ----------
+    .. [1] Askar, S., et al. On Solving Pentadiagonal Linear Systems via Transformations.
+           Mathematical Problems in Engineering, 2015, 232456.
+
+    """
+    lhs = np.asarray(ab, dtype=float)
+    rhs = np.asarray(b, dtype=float)
+    # TODO look at how scipy handles overwrite_[ab][b] for when np.asarray already copies
+    # the data
+    rows, columns = ab.shape
+    if rows != 5:
+        raise ValueError('ab matrix must have 5 rows')
+    if columns <= 3:
+        # pentapy special-cased this, but not worth handling in pybaselines since the lhs should
+        # never only have 3 columns -> just throw an error to prevent numba mis-handling this
+        # TODO could also just shift the rows back to LAPACK format and send to solve_banded
+        raise ValueError('ab matrix must have at least 4 rows')
+
+    func = {1: ptrans_1, 2: ptrans_2}[solver]
+    result, info = func(lhs, rhs, overwrite_ab, overwrite_b)
+    if info > 0:
+        raise np.linalg.LinAlgError(f'Matrix is singular at row index {info - 1}')
+
+    return result
+

--- a/pybaselines/_banded_solvers.py
+++ b/pybaselines/_banded_solvers.py
@@ -378,9 +378,9 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
         :func:`scipy.linalg.solve_banded`).
     b : numpy.ndarray, shape (M,) or (M, N)
         The right-hand side of the equation.
-    solver : {1, 2}
-        The solver to use. 1 designates the PTRANS-I algorithm from [1]_, and 2 designates
-        the PTRANS-II algorithm from [1]_.
+    solver : {1, 2}, optional
+        The solver to use. 1 (default) designates the PTRANS-I algorithm from [1]_, and 2
+        designates the PTRANS-II algorithm from [1]_.
     overwrite_ab : bool, optional
         Whether to overwrite `ab` when solving. Default is False.
     overwrite_b : bool, optional
@@ -394,7 +394,8 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
     Raises
     ------
     ValueError
-        Raised if `ab` has less than 3 columns or if `ab` does not have 5 rows.
+        Raised if `ab` has less than 3 columns or if `ab` does not have 5 rows. Also
+        raised if `solver` is not 1 or 2.
     numpy.linalg.LinAlgError
         Raised if `ab` is singular.
 
@@ -412,7 +413,9 @@ def solve_banded_penta(ab, b, solver=1, overwrite_ab=False, overwrite_b=False):
     rows, columns = ab.shape
     if rows != 5:
         raise ValueError('ab matrix must have 5 rows')
-    if columns < 4:
+    elif solver not in (1, 2):
+        raise ValueError(f'solver must be 1 or 2, but instead was {solver}')
+    elif columns < 4:
         # solvers always directly access first 4 columns, so use solve_banded instead
         return solve_banded(
             (2, 2), lhs, rhs, overwrite_ab=overwrite_ab, overwrite_b=overwrite_b,

--- a/pybaselines/_banded_utils.py
+++ b/pybaselines/_banded_utils.py
@@ -821,7 +821,7 @@ class PenalizedSystem:
         self._update_bands()
 
     def solve(self, lhs, rhs, overwrite_ab=False, overwrite_b=False,
-              check_finite=False, l_and_u=None, check_output=False):
+              check_finite=False, l_and_u=None):
         """
         Solves the equation ``A @ x = rhs``, given `A` in banded format as `lhs`.
 

--- a/pybaselines/_compat.py
+++ b/pybaselines/_compat.py
@@ -13,16 +13,6 @@ from scipy import integrate, sparse
 
 
 try:
-    from pentapy import solve as _pentapy_solve
-    _HAS_PENTAPY = True
-except ImportError:
-    _HAS_PENTAPY = False
-
-    def _pentapy_solve(*args, **kwargs):
-        """Dummy function in case pentapy is not installed."""
-        raise NotImplementedError('must have pentapy installed to use its solver')
-
-try:
     from numba import jit, prange
     _HAS_NUMBA = True
 except ImportError:

--- a/pybaselines/_spline_utils.py
+++ b/pybaselines/_spline_utils.py
@@ -655,11 +655,9 @@ class PSpline(PenalizedSystem):
             If True (default), will allow only using the lower bands of the penalty matrix,
             which allows using :func:`scipy.linalg.solveh_banded` instead of the slightly
             slower :func:`scipy.linalg.solve_banded`.
-        reverse_diags : {False, True, None}, optional
+        reverse_diags : bool, optional
             If True, will reverse the order of the diagonals of the squared difference
-            matrix. If False (default), will never reverse the diagonals. If None, will
-            only reverse the diagonals if using pentapy's solver (which is set to False
-            for PSpline).
+            matrix. Default is False.
 
         Raises
         ------
@@ -682,7 +680,7 @@ class PSpline(PenalizedSystem):
 
         super().__init__(
             self.basis._num_bases, lam, diff_order, allow_lower, reverse_diags,
-            allow_pentapy=False, padding=self.basis.spline_degree - diff_order
+            allow_penta=False, padding=self.basis.spline_degree - diff_order
         )
         self.coef = None
 
@@ -743,9 +741,10 @@ class PSpline(PenalizedSystem):
 
         Notes
         -----
-        `allow_pentapy` is always set to False since the time needed to go from a lower to full
-        banded matrix and shifting the rows removes any speedup from using pentapy's solver. It
-        also reduces the complexity of setting up the equations.
+        `allow_penta` is always set to False since the time needed to go from a lower to full
+        banded matrix removes any speedup from using the pentadiagonal solver. Besides, the most
+        common setup, cubic splines, have a bandwidth of 3 and would not use the
+        pentadiagonal solvers anyway.
 
         Adds padding to the penalty diagonals to accomodate the different shapes of the spline
         basis and the penalty to speed up calculations when the two are added.
@@ -753,7 +752,7 @@ class PSpline(PenalizedSystem):
         """
         self.reset_diagonals(
             lam=lam, diff_order=diff_order, allow_lower=allow_lower, reverse_diags=reverse_diags,
-            allow_pentapy=False, padding=self.basis.spline_degree - diff_order
+            allow_penta=False, padding=self.basis.spline_degree - diff_order
         )
 
     # adapted from scipy (scipy/interpolate/_bsplines.py/make_lsq_spline); see license above

--- a/pybaselines/two_d/_algorithm_setup.py
+++ b/pybaselines/two_d/_algorithm_setup.py
@@ -32,11 +32,6 @@ class _Algorithm2D:
 
     Attributes
     ----------
-    petapy_solver : int or str
-        Only used to pass to a new :class:`~.Baseline` object when using
-        :meth:`.Baseline2D.individual_axes`. The integer or string designating which solver
-        to use if using pentapy. See :func:`pentapy.solve` for available options, although
-        1 or 2 are the most relevant options. Default is 2.
     x : numpy.ndarray or None
         The x-values for the object. If initialized with None, then `x` is initialized the
         first function call to have the same size as the input `data.shape[-2]` and has min
@@ -194,32 +189,34 @@ class _Algorithm2D:
         the solver to prefer for solving banded linear systems in 1D. See
         :attr:`~.Baseline.banded_solver` for more information.  Default is 2.
 
-        This typically does not need to be modified since all solvers have relatively
-        the same numerical stability and is mostly for internal testing.
-
         """
         return self._banded_solver
 
     @banded_solver.setter
     def banded_solver(self, solver):
         """
-        Sets the solver for 1D banded systems.
+        Sets the solver to use for 1D banded linear systems.
 
         Parameters
         ----------
         solver : {1, 2, 3, 4}
             An integer designating the solver. Setting to 1 or 2 will use the ``PTRANS-I``
-            and ``PTRANS-II`` solvers, respectively, from :func:`pentapy.solve` if
-            ``pentapy`` is installed and the linear system is pentadiagonal. Otherwise,
-            it will use :func:`scipy.linalg.solveh_banded` if the system is symmetric,
-            else :func:`scipy.linalg.solve_banded`. Setting ``banded_solver`` to 3
-            will only use the SciPy solvers following the same logic, and 4 will
-            force usage of :func:`scipy.linalg.solve_banded`.
+            and ``PTRANS-II`` solvers, respectively, from [1]_ if ``numba`` is installed
+            and the linear system is pentadiagonal. Otherwise, it will use
+            :func:`scipy.linalg.solveh_banded` if the system is symmetric, else
+            :func:`scipy.linalg.solve_banded`. Setting ``banded_solver`` to 3 will only
+            use the SciPy solvers following the same logic, and 4 will force usage of
+            :func:`scipy.linalg.solve_banded`.
 
         Raises
         ------
         ValueError
             Raised if `solver` is not an integer between 1 and 4.
+
+        References
+        ----------
+        .. [1] Askar, S., et al. On Solving Pentadiagonal Linear Systems via
+            Transformations. Mathematical Problems in Engineering, 2015, 232456.
 
         """
         if isinstance(solver, bool) or solver not in {1, 2, 3, 4}:
@@ -232,7 +229,7 @@ class _Algorithm2D:
     @property
     def pentapy_solver(self):
         """
-        The solver if using ``pentapy`` to solve banded equations.
+        The solver if using the dedicated pentadiagonal solvers to solve banded equations.
 
         .. deprecated:: 1.2
             The `pentapy_solver` property is deprecated and will be removed in

--- a/pybaselines/whittaker.py
+++ b/pybaselines/whittaker.py
@@ -252,7 +252,7 @@ class _Whittaker(_Algorithm):
         for i in range(1, max_iter + 2):
             baseline = whittaker_system.solve(
                 whittaker_system.add_diagonal(weight_array), weight_array * y,
-                overwrite_b=True, check_output=True
+                overwrite_b=True
             )
             new_weights, residual_l1_norm, exit_early = _weighting._airpls(
                 y, baseline, i, normalize_weights

--- a/pybaselines/whittaker.py
+++ b/pybaselines/whittaker.py
@@ -170,8 +170,6 @@ class _Whittaker(_Algorithm):
         y, weight_array, whittaker_system = self._setup_whittaker(data, lam, diff_order, weights)
         lambda_1 = _check_lam(lam_1)
         diff_1_diags = diff_penalty_diagonals(self._size, 1, whittaker_system.lower, 1)
-        if whittaker_system.using_pentapy:
-            diff_1_diags = diff_1_diags[::-1]
         whittaker_system.add_penalty(lambda_1 * diff_1_diags)
 
         # fast calculation of lam_1 * (D_1.T @ D_1) @ y
@@ -406,15 +404,13 @@ class _Whittaker(_Algorithm):
 
         diff_1_diagonals = diff_penalty_diagonals(self._size, 1, False, padding=diff_order - 1)
         whittaker_system.add_penalty(diff_1_diagonals)
-        if whittaker_system.using_pentapy:
-            whittaker_system.reverse_penalty()
 
         tol_history = np.empty(max_iter + 1)
         lower_upper_bands = (diff_order, diff_order)
         for i in range(1, max_iter + 2):
-            penalty_with_weights = diff_n_diagonals * weight_array
-            if not whittaker_system.using_pentapy:
-                penalty_with_weights = _shift_rows(penalty_with_weights, diff_order, diff_order)
+            penalty_with_weights = _shift_rows(
+                diff_n_diagonals * weight_array, diff_order, diff_order
+            )
             baseline = whittaker_system.solve(
                 whittaker_system.penalty + penalty_with_weights, weight_array * y,
                 overwrite_ab=True, overwrite_b=True, l_and_u=lower_upper_bands
@@ -586,8 +582,7 @@ class _Whittaker(_Algorithm):
         for i in range(max_iter + 1):
             lhs = whittaker_system.penalty * alpha_array
             lhs[main_diag_idx] = lhs[main_diag_idx] + weight_array
-            if not whittaker_system.using_pentapy:
-                lhs = _shift_rows(lhs, diff_order, diff_order)
+            lhs = _shift_rows(lhs, diff_order, diff_order)
             baseline = whittaker_system.solve(
                 lhs, weight_array * y, overwrite_ab=True, overwrite_b=True,
                 l_and_u=lower_upper_bands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ Documentation = "https://pybaselines.readthedocs.io"
 
 [project.optional-dependencies]
 full = [
-    "pentapy>=1.1",  # 1.1.1 is first version with wheels for python 3.9; don't pin patch versions
     "numba>=0.53",  # first to allow usage with python 3.9
 ]
 test = [

--- a/requirements/requirements-documentation.txt
+++ b/requirements/requirements-documentation.txt
@@ -3,7 +3,6 @@
 matplotlib==3.10.1
 numba==0.61.0
 numpydoc==1.8.0
-pentapy==1.3.0
 sphinx==8.2.3
 sphinx-copybutton==0.5.2
 sphinx-gallery==0.19.0

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -17,16 +17,6 @@ import pytest
 import pybaselines
 
 
-try:
-    import pentapy  # noqa
-except ImportError:
-    _HAS_PENTAPY = False
-else:
-    _HAS_PENTAPY = True
-
-has_pentapy = pytest.mark.skipif(not _HAS_PENTAPY, reason='pentapy is not installed')
-
-
 def ensure_deprecation(deprecation_major, deprecation_minor):
     """Decorator to ensure deprecations are performed as scheduled.
 

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -49,13 +49,13 @@ def test_setup_whittaker_diff_matrix(small_data, algorithm, lam, diff_order,
 
     numpy_diff = np.diff(np.eye(small_data.shape[0]), diff_order, 0)
     desired_diagonals = dia_object(lam * (numpy_diff.T @ numpy_diff)).data[::-1]
-    if allow_lower and not whittaker_system.using_pentapy:
+    if allow_lower and not whittaker_system.using_penta:
         # only include the lower diagonals
         desired_diagonals = desired_diagonals[diff_order:]
 
     # the diagonals should be in the opposite order as the diagonal matrix's data
     # if reverse_diags is False
-    if reverse_diags or (whittaker_system.using_pentapy and reverse_diags is not False):
+    if reverse_diags or (whittaker_system.using_penta and reverse_diags is not False):
         desired_diagonals = desired_diagonals[::-1]
 
     assert_allclose(whittaker_system.penalty, desired_diagonals, 1e-10)
@@ -151,14 +151,14 @@ def test_setup_whittaker_reset_penalized_system(small_data, algorithm, diff_orde
     numpy_diff = np.diff(np.eye(small_data.shape[0]), diff_order, 0)
     original_diagonals = dia_object(numpy_diff.T @ numpy_diff).data[::-1]
     desired_diagonals = lam * original_diagonals
-    if allow_lower and not whittaker_system.using_pentapy:
+    if allow_lower and not whittaker_system.using_penta:
         # only include the lower diagonals
         desired_diagonals = desired_diagonals[diff_order:]
         original_diagonals = original_diagonals[diff_order:]
 
     # the diagonals should be in the opposite order as the diagonal matrix's data
     # if reverse_diags is False
-    if reverse_diags or (whittaker_system.using_pentapy and reverse_diags is not False):
+    if reverse_diags or (whittaker_system.using_penta and reverse_diags is not False):
         desired_diagonals = desired_diagonals[::-1]
         original_diagonals = original_diagonals[::-1]
 
@@ -679,7 +679,7 @@ def test_algorithm_class_init(input_x, check_finite, assume_sorted, output_dtype
     assert algorithm._check_finite == check_finite
     assert algorithm._dtype == output_dtype
     assert algorithm.banded_solver == 2
-    assert algorithm._pentapy_solver == 2
+    assert algorithm._penta_solver == 2
 
     if input_x:
         assert algorithm._size == len(x)
@@ -1022,14 +1022,14 @@ def test_override_x_whittaker(algorithm):
     banded_solver = 1
 
     default_banded_solver = algorithm.banded_solver
-    # sanity check that the tested pentapy_solver is not the default
+    # sanity check that the tested banded_solver is not the default
     assert banded_solver != default_banded_solver
 
     _, _, whittaker_system = algorithm._setup_whittaker(np.arange(old_len), diff_order=diff_order)
-    # whittaker_system's pentapy solver should be the default (2) since it is not coupled with
+    # whittaker_system's penta_solver should be the default (2) since it is not coupled with
     # the algorithm object
     algorithm.banded_solver = banded_solver
-    assert whittaker_system.pentapy_solver == default_banded_solver
+    assert whittaker_system.penta_solver == default_banded_solver
     # sanity check
     assert whittaker_system.diff_order == diff_order
 
@@ -1037,12 +1037,12 @@ def test_override_x_whittaker(algorithm):
     new_x = np.arange(new_len)
     new_algorithm = algorithm._override_x(new_x)
     assert new_algorithm.banded_solver == banded_solver
-    assert new_algorithm._pentapy_solver == banded_solver
+    assert new_algorithm._penta_solver == banded_solver
     _, _, new_whittaker_system = new_algorithm._setup_whittaker(
         np.arange(new_len), diff_order=new_diff_order
     )
     assert new_whittaker_system.diff_order == new_diff_order
-    assert new_whittaker_system.pentapy_solver == banded_solver
+    assert new_whittaker_system.penta_solver == banded_solver
 
 
 def test_override_x_spline(algorithm):
@@ -1081,14 +1081,14 @@ def test_deprecated_pentapy_solver(algorithm):
 
 @pytest.mark.parametrize('banded_solver', (1, 2, 3, 4))
 def test_banded_solver(algorithm, banded_solver):
-    """Ensures setting banded_solver also sets the correct pentapy_solver."""
+    """Ensures setting banded_solver also sets the correct _penta_solver."""
     if banded_solver < 3:
-        expected_pentapy_solver = banded_solver
+        expected_penta_solver = banded_solver
     else:
-        expected_pentapy_solver = 1
+        expected_penta_solver = 2
 
     algorithm.banded_solver = banded_solver
-    assert algorithm._pentapy_solver == expected_pentapy_solver
+    assert algorithm._penta_solver == expected_penta_solver
     assert algorithm.banded_solver == banded_solver
 
 

--- a/tests/test_algorithm_setup.py
+++ b/tests/test_algorithm_setup.py
@@ -35,7 +35,7 @@ def algorithm():
 @pytest.mark.parametrize('diff_order', (1, 2, 3))
 @pytest.mark.parametrize('lam', (1, 20))
 @pytest.mark.parametrize('allow_lower', (True, False))
-@pytest.mark.parametrize('reverse_diags', (True, False, None))
+@pytest.mark.parametrize('reverse_diags', (True, False))
 def test_setup_whittaker_diff_matrix(small_data, algorithm, lam, diff_order,
                                      allow_lower, reverse_diags):
     """Ensures output difference matrix diagonal data is in desired format."""
@@ -129,12 +129,16 @@ def test_setup_whittaker_array_lam(small_data):
 
 @pytest.mark.parametrize('diff_order', (1, 2, 3))
 @pytest.mark.parametrize('allow_lower', (True, False))
-@pytest.mark.parametrize('reverse_diags', (True, False, None))
+@pytest.mark.parametrize('reverse_diags', (True, False))
 def test_setup_whittaker_reset_penalized_system(small_data, algorithm, diff_order, allow_lower,
                                                 reverse_diags):
     """Ensures the whittaker_system is correctly updated when reusing."""
     if reverse_diags and allow_lower:
-        # this configuration is never used
+        # this configuration should never be used
+        with pytest.raises(ValueError):
+            _, _, whittaker_system = algorithm._setup_whittaker(
+                small_data, 1, diff_order, allow_lower=allow_lower, reverse_diags=reverse_diags
+            )
         return
 
     lam = 20.5

--- a/tests/test_banded_solvers.py
+++ b/tests/test_banded_solvers.py
@@ -54,7 +54,8 @@ def pentapy_ptrans1(mat_flat, rhs):
     Parameters
     ----------
     lhs : numpy.ndarray, shape (5, M)
-        The pentadiagonal matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+        The pentadiagonal matrix `A` in row-wise banded format (see
+        https://geostat-framework.readthedocs.io/projects/pentapy/en/stable/examples/index.html).
     rhs : numpy.ndarray, shape (M,) or (M, N)
         The right-hand side of the equation.
 
@@ -148,7 +149,8 @@ def pentapy_ptrans2(mat_flat, rhs):
     Parameters
     ----------
     lhs : numpy.ndarray, shape (5, M)
-        The pentadiagonal matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+        The pentadiagonal matrix `A` in row-wise banded format (see
+        https://geostat-framework.readthedocs.io/projects/pentapy/en/stable/examples/index.html).
     rhs : numpy.ndarray, shape (M,) or (M, N)
         The right-hand side of the equation.
 

--- a/tests/test_banded_solvers.py
+++ b/tests/test_banded_solvers.py
@@ -1,0 +1,398 @@
+# -*- coding: utf-8 -*-
+"""Tests for pybaselines._banded_solvers.
+
+The functions `pentapy_ptrans1` and `pentapy_ptrans2` were adapted from `pentapy`
+(https://github.com/GeoStat-Framework/pentapy) (last accessed March 25, 2025), which was
+licensed under the MIT license below.
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Sebastian Müller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+@author: Donald Erb
+Created on April 10, 2025
+
+"""
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+from scipy.linalg import solve_banded
+
+from pybaselines import _banded_solvers, _banded_utils
+from pybaselines._compat import jit
+
+from .base_tests import get_data
+
+
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
+def pentapy_ptrans1(mat_flat, rhs):
+    """
+    The ptrans1 solver from pentapy, for testing.
+
+    Solves the equation ``A @ x = rhs``, given `A` in row-wise banded format as `mat_flat`.
+
+    Parameters
+    ----------
+    lhs : numpy.ndarray, shape (5, M)
+        The pentadiagonal matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+    rhs : numpy.ndarray, shape (M,) or (M, N)
+        The right-hand side of the equation.
+
+    Returns
+    -------
+    result : numpy.ndarray, shape (M,) or (M, N)
+        The solution to the linear equation.
+    factorization : numpy.ndarray, shape (5, M)
+        The factorization of the input `lhs`.
+
+    Notes
+    -----
+    All modifications to the function `` from pentapy are noted, except for linting corrections.
+
+    Allows for checking both the calculated result and the factorization of the
+    input banded matrix.
+
+    """
+    mat_j = mat_flat.shape[1]
+
+    result = np.zeros(rhs.shape)  # modified compared to pentapy to allow multiple rhs
+    ze = np.zeros(rhs.shape)  # modified compared to pentapy to allow multiple rhs
+
+    # modified from pentapy to allow for outputting the factorization
+    factorization = np.zeros((5, mat_j))
+    al = factorization[1]  # np.zeros(mat_j)  alpha variables
+    be = factorization[0]  # np.zeros(mat_j)  beta variables
+    ga = factorization[3]  # np.zeros(mat_j)  gamma variables
+    mu = factorization[2]  # np.zeros(mat_j)  mu variables
+    factorization[4] = mat_flat[4]  # e variables, unmodified within the factorization
+
+    mu[0] = mat_flat[2, 0]
+    al[0] = mat_flat[1, 0] / mu[0]
+    be[0] = mat_flat[0, 0] / mu[0]
+    ze[0] = rhs[0] / mu[0]
+
+    ga[1] = mat_flat[3, 1]
+    mu[1] = mat_flat[2, 1] - al[0] * ga[1]
+    al[1] = (mat_flat[1, 1] - be[0] * ga[1]) / mu[1]
+    be[1] = mat_flat[0, 1] / mu[1]
+    ze[1] = (rhs[1] - ze[0] * ga[1]) / mu[1]
+
+    for i in range(2, mat_j - 2):
+        ga[i] = mat_flat[3, i] - al[i - 2] * mat_flat[4, i]
+        mu[i] = mat_flat[2, i] - be[i - 2] * mat_flat[4, i] - al[i - 1] * ga[i]
+        al[i] = (mat_flat[1, i] - be[i - 1] * ga[i]) / mu[i]
+        be[i] = mat_flat[0, i] / mu[i]
+        ze[i] = (rhs[i] - ze[i - 2] * mat_flat[4, i] - ze[i - 1] * ga[i]) / mu[i]
+
+    ga[mat_j - 2] = mat_flat[3, mat_j - 2] - al[mat_j - 4] * mat_flat[4, mat_j - 2]
+    mu[mat_j - 2] = (
+        mat_flat[2, mat_j - 2]
+        - be[mat_j - 4] * mat_flat[4, mat_j - 2]
+        - al[mat_j - 3] * ga[mat_j - 2]
+    )
+    al[mat_j - 2] = (mat_flat[1, mat_j - 2] - be[mat_j - 3] * ga[mat_j - 2]) / mu[mat_j - 2]
+
+    ga[mat_j - 1] = mat_flat[3, mat_j - 1] - al[mat_j - 3] * mat_flat[4, mat_j - 1]
+    mu[mat_j - 1] = (
+        mat_flat[2, mat_j - 1]
+        - be[mat_j - 3] * mat_flat[4, mat_j - 1]
+        - al[mat_j - 2] * ga[mat_j - 1]
+    )
+
+    ze[mat_j - 2] = (
+        rhs[mat_j - 2] - ze[mat_j - 4] * mat_flat[4, mat_j - 2] - ze[mat_j - 3] * ga[mat_j - 2]
+    ) / mu[mat_j - 2]
+    ze[mat_j - 1] = (
+        rhs[mat_j - 1] - ze[mat_j - 3] * mat_flat[4, mat_j - 1] - ze[mat_j - 2] * ga[mat_j - 1]
+    ) / mu[mat_j - 1]
+
+    # Backward substitution
+    result[mat_j - 1] = ze[mat_j - 1]
+    result[mat_j - 2] = ze[mat_j - 2] - al[mat_j - 2] * result[mat_j - 1]
+
+    for i in range(mat_j - 3, -1, -1):
+        result[i] = ze[i] - al[i] * result[i + 1] - be[i] * result[i + 2]
+
+    return result, factorization
+
+
+# adapted from pentapy (https://github.com/GeoStat-Framework/pentapy); see license above
+@jit(nopython=True, cache=True)
+def pentapy_ptrans2(mat_flat, rhs):
+    """
+    The ptrans2 solver from pentapy, for testing.
+
+    Solves the equation ``A @ x = rhs``, given `A` in row-wise banded format as `mat_flat`.
+
+    Parameters
+    ----------
+    lhs : numpy.ndarray, shape (5, M)
+        The pentadiagonal matrix `A` in row-wise banded format (see :func:`pentapy.solve`).
+    rhs : numpy.ndarray, shape (M,) or (M, N)
+        The right-hand side of the equation.
+
+    Returns
+    -------
+    result : numpy.ndarray, shape (M,) or (M, N)
+        The solution to the linear equation.
+    factorization : numpy.ndarray, shape (5, M)
+        The factorization of the input `lhs`.
+
+    Notes
+    -----
+    All modifications to the function `` from pentapy are noted, except for linting corrections.
+
+    Allows for checking both the calculated result and the factorization of the
+    input banded matrix.
+
+    """
+    mat_j = mat_flat.shape[1]
+
+    result = np.zeros(rhs.shape)  # modified compared to pentapy to allow multiple rhs
+    we = np.zeros(rhs.shape)  # modified compared to pentapy to allow multiple rhs
+
+    # modified from pentapy to allow for outputting the factorization
+    factorization = np.zeros((5, mat_j))
+    ro = factorization[1]  # np.zeros(mat_j)  rho variables
+    si = factorization[3]  # np.zeros(mat_j)  sigma variables
+    ps = factorization[2]  # np.zeros(mat_j)  psi variables
+    ph = factorization[4]  # phi variables, unmodified within the factorization
+    factorization[0] = mat_flat[0]  # b variables, unmodified within the factorization
+
+    ps[mat_j - 1] = mat_flat[2, mat_j - 1]
+    si[mat_j - 1] = mat_flat[3, mat_j - 1] / ps[mat_j - 1]
+    ph[mat_j - 1] = mat_flat[4, mat_j - 1] / ps[mat_j - 1]
+    we[mat_j - 1] = rhs[mat_j - 1] / ps[mat_j - 1]
+
+    ro[mat_j - 2] = mat_flat[1, mat_j - 2]
+    ps[mat_j - 2] = mat_flat[2, mat_j - 2] - si[mat_j - 1] * ro[mat_j - 2]
+    si[mat_j - 2] = (mat_flat[3, mat_j - 2] - ph[mat_j - 1] * ro[mat_j - 2]) / ps[mat_j - 2]
+    ph[mat_j - 2] = mat_flat[4, mat_j - 2] / ps[mat_j - 2]
+    we[mat_j - 2] = (rhs[mat_j - 2] - we[mat_j - 1] * ro[mat_j - 2]) / ps[mat_j - 2]
+
+    for i in range(mat_j - 3, 1, -1):
+        ro[i] = mat_flat[1, i] - si[i + 2] * mat_flat[0, i]
+        ps[i] = mat_flat[2, i] - ph[i + 2] * mat_flat[0, i] - si[i + 1] * ro[i]
+        si[i] = (mat_flat[3, i] - ph[i + 1] * ro[i]) / ps[i]
+        ph[i] = mat_flat[4, i] / ps[i]
+        we[i] = (rhs[i] - we[i + 2] * mat_flat[0, i] - we[i + 1] * ro[i]) / ps[i]
+
+    ro[1] = mat_flat[1, 1] - si[3] * mat_flat[0, 1]
+    ps[1] = mat_flat[2, 1] - ph[3] * mat_flat[0, 1] - si[2] * ro[1]
+    si[1] = (mat_flat[3, 1] - ph[2] * ro[1]) / ps[1]
+
+    ro[0] = mat_flat[1, 0] - si[2] * mat_flat[0, 0]
+    ps[0] = mat_flat[2, 0] - ph[2] * mat_flat[0, 0] - si[1] * ro[0]
+
+    we[1] = (rhs[1] - we[3] * mat_flat[0, 1] - we[2] * ro[1]) / ps[1]
+    we[0] = (rhs[0] - we[2] * mat_flat[0, 0] - we[1] * ro[0]) / ps[0]
+
+    # Foreward substitution
+    result[0] = we[0]
+    result[1] = we[1] - si[1] * result[0]
+
+    for i in range(2, mat_j):
+        result[i] = we[i] - si[i] * result[i - 1] - ph[i] * result[i - 2]
+
+    return result, factorization
+
+
+@pytest.mark.parametrize('data_size', (100, 1000, 10000))
+@pytest.mark.parametrize('solver', (1, 2))
+@pytest.mark.parametrize('weights_enum', (0, 1))
+@pytest.mark.parametrize('lam', np.logspace(-4, 8, 6, base=10, dtype=float))
+@pytest.mark.parametrize('two_d', (False, True))
+@pytest.mark.parametrize('overwrite_ab', (False, True))
+@pytest.mark.parametrize('overwrite_b', (False, True))
+def test_whittaker_solve_symmetric(data_size, solver, weights_enum, lam, two_d, overwrite_ab,
+                                   overwrite_b):
+    """Ensures banded pentadiagonal solvers work for symmetric Whittaker smoothing systems."""
+    x, y = get_data(num_points=data_size)
+    if two_d:
+        y = y * np.linspace(0.5, 10.5, 10)[:, None]
+        assert y.ndim == 2  # sanity check that it's 2d
+    if weights_enum == 0:  # equal weights
+        weights = np.ones(data_size)
+    else:
+        weights = np.random.default_rng(123).uniform(1e-6, 1, size=data_size)
+
+    penalized_system = _banded_utils.PenalizedSystem(
+        data_size, lam=lam, diff_order=2, allow_lower=False
+    )
+    lhs = penalized_system.add_diagonal(weights)
+    rhs = y * weights
+    if two_d:
+        rhs = rhs.T
+
+    # treat LU factorization as the "known" solution as a sanity check that the
+    # equation was solved correctly
+    scipy_solution = solve_banded((2, 2), lhs, rhs)
+
+    # pentapy solver expects lhs to be row-wise banded, which can be done by reversing
+    # since lhs is symmetric for this test
+    pentapy_solver = {1: pentapy_ptrans1, 2: pentapy_ptrans2}[solver]
+    pentapy_solution, pentapy_factorization = pentapy_solver(lhs[::-1], rhs)
+
+    if overwrite_ab:
+        input_lhs = lhs.copy()
+    else:
+        input_lhs = lhs
+    if overwrite_b:
+        input_rhs = rhs.copy()
+    else:
+        input_rhs = rhs
+
+    output = _banded_solvers.solve_banded_penta(
+        input_lhs, input_rhs, solver=solver, overwrite_ab=overwrite_ab, overwrite_b=overwrite_b
+    )
+    # ensure it actually overwrites the input when expected to, and doesn't when not
+    if overwrite_ab:
+        assert not np.allclose(input_lhs, lhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_lhs, lhs, rtol=1e-16, atol=1e-16)
+    if overwrite_b:
+        assert not np.allclose(input_rhs, rhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_rhs, rhs, rtol=1e-16, atol=1e-16)
+
+    # also test the underlying solver
+    if overwrite_ab:
+        input_lhs = lhs.copy()
+    else:
+        input_lhs = lhs
+    if overwrite_b:
+        input_rhs = rhs.copy()
+    else:
+        input_rhs = rhs
+    underlying_solver = {1: _banded_solvers._ptrans_1, 2: _banded_solvers._ptrans_2}[solver]
+    output2, info = underlying_solver(
+        input_lhs, input_rhs, overwrite_ab=overwrite_ab, overwrite_b=overwrite_b
+    )
+    assert info == 0
+    if overwrite_ab:
+        assert not np.allclose(input_lhs, lhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_lhs, lhs, rtol=1e-16, atol=1e-16)
+    if overwrite_b:
+        assert not np.allclose(input_rhs, rhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_rhs, rhs, rtol=1e-16, atol=1e-16)
+
+    assert_allclose(output, scipy_solution, atol=1e-10, rtol=5e-8)
+    assert_allclose(output2, scipy_solution, atol=1e-10, rtol=5e-8)
+    # put tighter tolerance on the pentapy comparison since it should be an exact
+    # replication of the algorithm
+    assert_allclose(output, pentapy_solution, atol=1e-16, rtol=1e-16)
+    assert_allclose(output2, pentapy_solution, atol=1e-16, rtol=1e-16)
+
+
+@pytest.mark.parametrize('data_size', (100, 1001, 10002))
+@pytest.mark.parametrize('solver', (1, 2))
+@pytest.mark.parametrize('weights_enum', (0, 1))
+@pytest.mark.parametrize('lam', np.logspace(-4, 8, 6, base=10, dtype=float))
+@pytest.mark.parametrize('two_d', (False, True))
+@pytest.mark.parametrize('overwrite_ab', (False, True))
+@pytest.mark.parametrize('overwrite_b', (False, True))
+def test_whittaker_solve_nonsymmetric(data_size, solver, weights_enum, lam, two_d, overwrite_ab,
+                                      overwrite_b):
+    """Ensures banded pentadiagonal solvers work for non-symmetric Whittaker smoothing systems."""
+    x, y = get_data(num_points=data_size)
+    if two_d:
+        y = y * np.linspace(0.5, 10.5, 10)[:, None]
+        assert y.ndim == 2  # sanity check that it's 2d
+    if weights_enum == 0:  # equal weights
+        weights = np.ones(data_size)
+    else:
+        weights = np.random.default_rng(123).uniform(1e-6, 1, size=data_size)
+
+    penalized_system = _banded_utils.PenalizedSystem(
+        data_size, lam=lam, diff_order=2, allow_lower=False
+    )
+    multiplier = 1 - 0.5 * weights  # similar array multiplier as used for drpls method
+    lhs = penalized_system.penalty * multiplier
+    lhs[2] += weights
+    lapack_lhs = _banded_utils._shift_rows(lhs.copy(), 2, 2)
+    rhs = y * weights
+    if two_d:
+        rhs = rhs.T
+
+    # treat LU factorization as the "known" solution as a sanity check that the
+    # equation was solved correctly
+    scipy_solution = solve_banded((2, 2), lapack_lhs, rhs)
+
+    # pentapy solver expects lhs to be row-wise banded, which should be the result
+    # after multiplying by an array
+    pentapy_solver = {1: pentapy_ptrans1, 2: pentapy_ptrans2}[solver]
+    pentapy_solution, pentapy_factorization = pentapy_solver(lhs, rhs)
+
+    if overwrite_ab:
+        input_lhs = lapack_lhs.copy()
+    else:
+        input_lhs = lapack_lhs
+    if overwrite_b:
+        input_rhs = rhs.copy()
+    else:
+        input_rhs = rhs
+
+    output = _banded_solvers.solve_banded_penta(
+        input_lhs, input_rhs, solver=solver, overwrite_ab=overwrite_ab, overwrite_b=overwrite_b
+    )
+    # ensure it actually overwrites the input when expected to, and doesn't when not
+    if overwrite_ab:
+        assert not np.allclose(input_lhs, lapack_lhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_lhs, lapack_lhs, rtol=1e-16, atol=1e-16)
+    if overwrite_b:
+        assert not np.allclose(input_rhs, rhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_rhs, rhs, rtol=1e-16, atol=1e-16)
+
+    # also test the underlying solver
+    if overwrite_ab:
+        input_lhs = lapack_lhs.copy()
+    else:
+        input_lhs = lapack_lhs
+    if overwrite_b:
+        input_rhs = rhs.copy()
+    else:
+        input_rhs = rhs
+    underlying_solver = {1: _banded_solvers._ptrans_1, 2: _banded_solvers._ptrans_2}[solver]
+    output2, info = underlying_solver(
+        input_lhs, input_rhs, overwrite_ab=overwrite_ab, overwrite_b=overwrite_b
+    )
+    assert info == 0
+    if overwrite_ab:
+        assert not np.allclose(input_lhs, lapack_lhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_lhs, lapack_lhs, rtol=1e-16, atol=1e-16)
+    if overwrite_b:
+        assert not np.allclose(input_rhs, rhs, rtol=1e-10, atol=1e-10)
+    else:
+        assert_allclose(input_rhs, rhs, rtol=1e-16, atol=1e-16)
+
+    assert_allclose(output, scipy_solution, atol=1e-10, rtol=5e-8)
+    assert_allclose(output2, scipy_solution, atol=1e-10, rtol=5e-8)
+    # put tighter tolerance on the pentapy comparison since it should be an exact
+    # replication of the algorithm
+    assert_allclose(output, pentapy_solution, atol=1e-16, rtol=1e-16)
+    assert_allclose(output2, pentapy_solution, atol=1e-16, rtol=1e-16)

--- a/tests/test_banded_utils.py
+++ b/tests/test_banded_utils.py
@@ -538,7 +538,6 @@ def test_penalized_system_setup(diff_order, allow_lower, reverse_diags):
             )
 
 
-@has_pentapy
 @pytest.mark.parametrize('diff_order', (1, 2, 3))
 @pytest.mark.parametrize('allow_lower', (True, False))
 @pytest.mark.parametrize('reverse_diags', (None, True, False))

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -16,16 +16,6 @@ from scipy import integrate, sparse
 
 from pybaselines import _compat
 
-from .base_tests import _HAS_PENTAPY
-
-
-def test_pentapy_installation():
-    """Ensure proper setup with pentapy."""
-    assert _compat._HAS_PENTAPY == _HAS_PENTAPY
-    if not _HAS_PENTAPY:
-        with pytest.raises(NotImplementedError):
-            _compat._pentapy_solve()
-
 
 def test_prange():
     """

--- a/tests/test_morphological.py
+++ b/tests/test_morphological.py
@@ -6,11 +6,13 @@ Created on March 20, 2021
 
 """
 
+from unittest import mock
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from pybaselines import morphological
+from pybaselines import _banded_utils, morphological
 
 from .base_tests import BaseTester, InputWeightsMixin, RecreationMixin, ensure_deprecation
 
@@ -62,15 +64,17 @@ class TestMPLS(MorphologicalTester, InputWeightsMixin, RecreationMixin):
     def test_pentadiagonal_solver(self, pentadiagonal_solver):
         """Ensure pentadiagonal solvers give similar result to SciPy's solvers."""
         self.algorithm.banded_solver = pentadiagonal_solver
-        pentapy_output = self.class_func(self.y, diff_order=2)[0]
+        # mock having numba so the solver is used even if numba is not installed
+        with mock.patch.object(_banded_utils, '_HAS_NUMBA', True):
+            pentadiagonal_output = self.class_func(self.y, diff_order=2)[0]
 
         self.algorithm.banded_solver = 3  # use solveh_banded
         solveh_output = self.class_func(self.y, diff_order=2)[0]
         self.algorithm.banded_solver = 4  # use solve_banded
         solve_output = self.class_func(self.y, diff_order=2)[0]
 
-        assert_allclose(pentapy_output, solveh_output, rtol=5e-5, atol=1e-8)
-        assert_allclose(pentapy_output, solve_output, rtol=5e-5, atol=1e-8)
+        assert_allclose(pentadiagonal_output, solveh_output, rtol=5e-5, atol=1e-8)
+        assert_allclose(pentadiagonal_output, solve_output, rtol=5e-5, atol=1e-8)
 
     @pytest.mark.parametrize('p', (-1, 2))
     def test_outside_p_fails(self, p):
@@ -223,15 +227,17 @@ class TestJBCD(MorphologicalTester):
     def test_pentadiagonal_solver(self, pentadiagonal_solver):
         """Ensure pentadiagonal solvers give similar result to SciPy's solvers."""
         self.algorithm.banded_solver = pentadiagonal_solver
-        pentapy_output = self.class_func(self.y, diff_order=2)[0]
+        # mock having numba so the solver is used even if numba is not installed
+        with mock.patch.object(_banded_utils, '_HAS_NUMBA', True):
+            pentadiagonal_output = self.class_func(self.y, diff_order=2)[0]
 
         self.algorithm.banded_solver = 3  # use solveh_banded
         solveh_output = self.class_func(self.y, diff_order=2)[0]
         self.algorithm.banded_solver = 4  # use solve_banded
         solve_output = self.class_func(self.y, diff_order=2)[0]
 
-        assert_allclose(pentapy_output, solveh_output, rtol=5e-5, atol=1e-8)
-        assert_allclose(pentapy_output, solve_output, rtol=5e-5, atol=1e-8)
+        assert_allclose(pentadiagonal_output, solveh_output, rtol=5e-5, atol=1e-8)
+        assert_allclose(pentadiagonal_output, solve_output, rtol=5e-5, atol=1e-8)
 
     def test_zero_gamma_passes(self):
         """Ensures gamma can be 0, which just does baseline correction without denoising."""

--- a/tests/test_spline_utils.py
+++ b/tests/test_spline_utils.py
@@ -307,7 +307,7 @@ def check_penalized_spline(penalized_system, expected_penalty, lam, diff_order,
     assert penalized_system.basis.knots.shape == (num_knots + 2 * spline_degree,)
     assert isinstance(penalized_system.basis.x, np.ndarray)
     assert penalized_system.basis._x_len == len(penalized_system.basis.x)
-    assert not penalized_system.using_pentapy
+    assert not penalized_system.using_penta
     if allow_lower:
         assert penalized_system.main_diagonal_index == 0
     else:
@@ -336,7 +336,7 @@ def test_pspline_setup(data_fixture, num_knots, spline_degree, diff_order,
     """
     Ensure the PSpline setup is correct.
 
-    Since `allow_pentapy` is always False for PSpline, the `lower` attribute of the
+    Since `allow_penta` is always False for PSpline, the `lower` attribute of the
     PenalizedSystem will always equal the input `allow_lower` and the `reversed`
     attribute will be equal to the bool of the input `reverse_diags` input (ie. None
     will also be False).

--- a/tests/test_spline_utils.py
+++ b/tests/test_spline_utils.py
@@ -330,7 +330,7 @@ def check_penalized_spline(penalized_system, expected_penalty, lam, diff_order,
 @pytest.mark.parametrize('num_knots', (10, 100))
 @pytest.mark.parametrize('diff_order', (1, 2, 3))
 @pytest.mark.parametrize('allow_lower', (True, False))
-@pytest.mark.parametrize('reverse_diags', (None, True, False))
+@pytest.mark.parametrize('reverse_diags', (True, False))
 def test_pspline_setup(data_fixture, num_knots, spline_degree, diff_order,
                        allow_lower, reverse_diags):
     """
@@ -355,23 +355,30 @@ def test_pspline_setup(data_fixture, num_knots, spline_degree, diff_order,
     spline_basis = _spline_utils.SplineBasis(
         x, num_knots=num_knots, spline_degree=spline_degree, check_finite=False
     )
-    pspline = _spline_utils.PSpline(
-        spline_basis, lam=lam, diff_order=diff_order, allow_lower=allow_lower,
-        reverse_diags=reverse_diags
-    )
-
-    check_penalized_spline(
-        pspline, expected_penalty, lam, diff_order, allow_lower,
-        bool(reverse_diags), spline_degree, num_knots, data_size
-    )
-    # also check that the reset_diagonal method performs similarly
-    pspline.reset_penalty_diagonals(
-        lam=lam, diff_order=diff_order, allow_lower=allow_lower, reverse_diags=reverse_diags
-    )
-    check_penalized_spline(
-        pspline, expected_penalty, lam, diff_order, allow_lower,
-        bool(reverse_diags), spline_degree, num_knots, data_size
-    )
+    if reverse_diags and allow_lower:
+        # this configuration should never be used
+        with pytest.raises(ValueError):
+            pspline = _spline_utils.PSpline(
+                spline_basis, lam=lam, diff_order=diff_order, allow_lower=allow_lower,
+                reverse_diags=reverse_diags
+            )
+    else:
+        pspline = _spline_utils.PSpline(
+            spline_basis, lam=lam, diff_order=diff_order, allow_lower=allow_lower,
+            reverse_diags=reverse_diags
+        )
+        check_penalized_spline(
+            pspline, expected_penalty, lam, diff_order, allow_lower,
+            bool(reverse_diags), spline_degree, num_knots, data_size
+        )
+        # also check that the reset_diagonal method performs similarly
+        pspline.reset_penalty_diagonals(
+            lam=lam, diff_order=diff_order, allow_lower=allow_lower, reverse_diags=reverse_diags
+        )
+        check_penalized_spline(
+            pspline, expected_penalty, lam, diff_order, allow_lower,
+            bool(reverse_diags), spline_degree, num_knots, data_size
+        )
 
 
 def test_spline_basis_non_finite_fails():

--- a/tests/test_whittaker.py
+++ b/tests/test_whittaker.py
@@ -101,20 +101,32 @@ class WhittakerTester(BaseTester, InputWeightsMixin, RecreationMixin):
 
         assert_allclose(solveh_output, solve_output, rtol=1e-6, atol=1e-8)
 
-    @has_pentapy
-    @pytest.mark.parametrize('pentapy_solver', (1, 2))
-    def test_pentapy_solver(self, pentapy_solver):
-        """Ensure pentapy solvers give similar result to SciPy's solvers."""
-        self.algorithm.banded_solver = pentapy_solver
-        pentapy_output = self.class_func(self.y)[0]
+    @pytest.mark.parametrize('pentadiagonal_solver', (1, 2))
+    def test_pentadiagonal_solver(self, pentadiagonal_solver):
+        """Ensure pentadiagonal solvers give similar result to SciPy's solvers."""
+        self.algorithm.banded_solver = pentadiagonal_solver
+        pentapy_output = self.class_func(self.y, diff_order=2)[0]
 
         self.algorithm.banded_solver = 3  # use solveh_banded if allowed
-        solveh_output = self.class_func(self.y)[0]
+        solveh_output = self.class_func(self.y, diff_order=2)[0]
         self.algorithm.banded_solver = 4  # force use solve_banded
-        solve_output = self.class_func(self.y)[0]
+        solve_output = self.class_func(self.y, diff_order=2)[0]
 
         assert_allclose(pentapy_output, solveh_output, rtol=5e-5, atol=1e-8)
         assert_allclose(pentapy_output, solve_output, rtol=5e-5, atol=1e-8)
+
+    @has_pentapy
+    @pytest.mark.parametrize('pentapy_solver', (1, 2))
+    def test_pentapy_comparison(self, pentapy_solver):
+        """Ensure vendored solvers give similar result to pentapy's solvers."""
+        self.algorithm.banded_solver = pentapy_solver
+        solve_penta_output = self.class_func(self.y, diff_order=2)[0]
+
+        # pass a negative value to tell it to use pentapy's versions
+        self.algorithm._pentapy_solver = -pentapy_solver
+        pentapy_output = self.class_func(self.y, diff_order=2)[0]
+
+        assert_allclose(solve_penta_output, pentapy_output, rtol=5e-5, atol=1e-10)
 
     def test_tol_history(self):
         """Ensures the 'tol_history' item in the parameter output is correct."""


### PR DESCRIPTION
<!--Please fill out all sections of the pull request template.-->

### Description
<!--Describe the pull request in detail, telling why the changes
are required and/or what problems they fix. Link or add the issue number
for any existing issues that the pull request solves.

Note that it is preferred to file an issue first, so that details can be
discussed/finalized before a pull request is created.-->
Vendors the PTRANS-I and PTRANS-II solvers from pentapy as private functions. The solvers were internally changed following the guidelines presented in pentapy issue 11 and pull request 27, as well as to fit some personal preferences. Changes outlined as follows:

1) Works natively on LAPACK banded format (column-wise) rather than row-wise banded format, which makes it easier to use alongside SciPy's banded solvers, especially when doing intermediate calculations with the banded matrices. Theoretically the extra indexing should require ~2N extra addtitions compared to the 19N-29 total operations in row-wise, but I didn't notice any timing increase when changing the internal logic to work column-wise rather than row-wise.
2) Supports one or multiple right hand sides. This could be done using broadcasting without having to factorize internally, so it was a nice feature to add without any major changes to the actual solver logic.
3) Added separate functions for taking the factorization and reusing for subsequent solves.
4) Actually raises an exception when the solve fails, rather than emitting a warning or silently returning nans.

Points (2) and (3) aren't of use in pybaselines yet, but the `optimize_lam` branch will benefit from them. 

The `using_pentapy` attribute of _banded_utils.PenalizedSystem was renamed to `using_penta`. It didn't need to be done, but a lot of my personal code uses the PenalizedSystem object and would otherwise potentially be using banded matrices in an unexpected band arrangement without any warning (why point (1) was done), so I thought it'd be better to cause any code using that attribute to fail rather than silently be in an unexpected band format.

Concerning performance, the direct solver is ~20-30% faster than the current main branch of pentapy thanks to improved indexing and solving without tracking the full factorization, both explained in pentapy issue 11. Both the direct solver and factorized solver produce identical outputs to pentapy's solvers, at least on all of the different Whittaker smoothing systems I've tested. Timings and correctness can be compared with the following gist: https://gist.github.com/derb12/1eff076884a5512fb5e833e47cea91bc

### Type of Pull Request
<!--Put an x in all boxes that apply, like so: - [x] Bug Fix-->

- [ ] Bug Fix
- [ ] New Feature
- [x] Miscellaneous Changes (refactor, code improvements, etc.)
- [x] Documentation or Example Programs

### Pull Request Checklist
<!--Fill in all boxes with an x to verify.

To run tests locally, type the following command within the pybaselines
directory: pytest .

To lint files using ruff to see if they pass PEP 8 standards and that
docstrings are okay, run the following command within the pybaselines
directory: ruff check .

To build documentation locally, type the following command within the
docs directory: make html
-->

- [x] New code and/or documentation is valid for use with the BSD 3-clause license.
- [x] New code is fully documented with docstrings that follow Numpy style,
      if applicable.
- [x] New code follows PEP 8 standards as closely as possible, if applicable.
- [x] Added/updated tests and ensured they pass locally, if applicable.
- [x] Verified that documentation builds locally, if applicable.
