### PR TITLE
TEST: Bump rtols to fix flaky tests

### DIFF
--- a/tests/test_spline_utils.py
+++ b/tests/test_spline_utils.py
@@ -620,7 +620,7 @@ def test_pspline_lam_extremes(data_fixture, diff_order, allow_lower, spline_degr
         # and both larger num_knots and larger diff_orders need larger lam for it to be a
         # polynomial, so have to reduce the relative tolerance; num_knots has a larger effect
         # than diff_order, so base the rtol on it
-        rtol = {50: 5e-4, 501: 5e-3}[num_knots]
+        rtol = {50: 1e-3, 501: 5e-3}[num_knots]
         assert_allclose(output, polynomial_fit, rtol=rtol, atol=1e-10)
 
     # for lam ~ 0, should just approximate the an interpolating spline

--- a/tests/test_whittaker.py
+++ b/tests/test_whittaker.py
@@ -324,7 +324,7 @@ class TestDrPLS(WhittakerTester):
             self.y, lam=lam, eta=eta, diff_order=diff_order, max_iter=max_iter, tol=tol
         )
 
-        assert_allclose(banded_output, sparse_output, rtol=1e-6, atol=1e-10)
+        assert_allclose(banded_output, sparse_output, rtol=1.5e-6, atol=1e-10)
 
 
 class TestIArPLS(WhittakerTester):
@@ -445,7 +445,7 @@ class TestAsPLS(WhittakerTester):
             asymmetric_coef=asymmetric_coef
         )[0]
 
-        rtol = {2: 1e-4, 3: 2e-4}[diff_order]
+        rtol = {2: 1.5e-4, 3: 3e-4}[diff_order]
         assert_allclose(banded_output, sparse_output, rtol=rtol, atol=1e-8)
 
 


### PR DESCRIPTION
<!--Please fill out all sections of the pull request template.-->

### Description
<!--Describe the pull request in detail, telling why the changes
are required and/or what problems they fix. Link or add the issue number
for any existing issues that the pull request solves.

Note that it is preferred to file an issue first, so that details can be
discussed/finalized before a pull request is created.-->
Slightly bumps the relative tolerances for a few tests to address the flaky CI behavior seen in #51, #53, #58, and #59.

Locally, for new venvs with the same os, python, numpy, scipy, and openblas versions, I can consistently reproduce the test failures on one machine (AMD cpu) but not another (Intel cpu, not using mkl), so these flaky tests may just have a small architecture dependence? When the tests fail, both on the CI and locally, they always produce the same output, so it's not like the output is random. Not worth devoting more time to this since simply bumping the rtol by half a magnitude addresses all failures.

### Type of Pull Request
<!--Put an x in all boxes that apply, like so: - [x] Bug Fix-->

- [ ] Bug Fix
- [ ] New Feature
- [x] Miscellaneous Changes (refactor, code improvements, etc.)
- [ ] Documentation or Example Programs

### Pull Request Checklist
<!--Fill in all boxes with an x to verify.

To run tests locally, type the following command within the pybaselines
directory: pytest .

To lint files using ruff to see if they pass PEP 8 standards and that
docstrings are okay, run the following command within the pybaselines
directory: ruff check .

To build documentation locally, type the following command within the
docs directory: make html
-->

- [x] New code and/or documentation is valid for use with the BSD 3-clause license.
- [n/a] New code is fully documented with docstrings that follow Numpy style,
      if applicable.
- [n/a] New code follows PEP 8 standards as closely as possible, if applicable.
- [x] Added/updated tests and ensured they pass locally, if applicable.
- [n/a] Verified that documentation builds locally, if applicable.
