### PR TITLE
DOC: Minor correction regarding the location of the optimal parameter

### DIFF
--- a/docs/examples/misc/plot_beads_param_selection.py
+++ b/docs/examples/misc/plot_beads_param_selection.py
@@ -7,9 +7,9 @@ This example examines the parameter selection criteria for :meth:`~pybaselines.B
 proposed by `Navarro-Huerta, J.A., et al. "Assisted baseline subtraction in complex chromatograms
 using the BEADS algorithm" <https://doi.org/10.1016/j.chroma.2017.05.057>`_. Note that the
 preprocessing of data using a parabola before performing `beads` from the same paper is examined
-in  :ref:`another example <sphx_glr_generated_examples_misc_plot_beads_preprocessing.py>`.
+in :ref:`another example <sphx_glr_generated_examples_misc_plot_beads_preprocessing.py>`.
 
-The proposed parameter selection process works by varying the parameter of interest (eg.
+The proposed parameter selection process works by varying the parameter of interest (e.g.
 `freq_cutoff`, `lam_0`, `lam_1`, etc.) and calculating the autocorrelation coefficient,
 :math:`r^2`, from the residual, ``data - baseline``, for each fit. The autocorrelation plots
 will show plateau regions in which the calculated baseline is fairly consistent with regards
@@ -42,8 +42,6 @@ def autocorrelation(residual):
 x, y, baseline = make_data(return_baseline=True)
 baseline_fitter = Baseline(x)
 
-fixed_kwargs = {'tol': 1e-3, 'asymmetry': 6}
-
 # %%
 # Before varying any parameters, the input data will first be transformed by taking
 # the log of the input. The benefit of this transformation for `beads` is twofold:
@@ -53,11 +51,10 @@ fixed_kwargs = {'tol': 1e-3, 'asymmetry': 6}
 #   difference compared to the baseline.
 #
 # * The regularization parameters for `beads` penalize the L1 norms, so they are not
-#   scale-invariant compared to methods like Whittaker smoothing which penalize the L2
-#   norm; this means that fitting ``y`` and ``100 * y`` would require changing the various
-#   `lam_d` parameters. Taking the log transform helps to put all data on the same
+#   scale-invariant, which means that fitting ``y`` and ``100 * y`` would require changing
+#   the various `lam_d` parameters. Taking the log transform helps to put all data on the same
 #   relative scale such that the necessary regularization parameters between different
-#   datasets will not vary as much as long as other factors remain constant (eg. the number
+#   datasets will not vary as much as long as other factors remain constant (e.g. the number
 #   of points, baseline curvature, etc.).
 min_y = y.min()
 y_transf = np.log(y - min_y + 1)  # offset to ensure all values > 0 to prevent issues with log
@@ -65,30 +62,24 @@ y_transf = np.log(y - min_y + 1)  # offset to ensure all values > 0 to prevent i
 # %%
 # The first parameter to vary will be the cutoff frequency, `freq_cutoff`, since it typically
 # has the most influence on the baseline fit. A general rule of thumb is a higher cutoff
-# frequency is required for baselines with more curvature.
+# frequency is required for more flexible baselines; in other words, a sinusoidal baseline
+# would required a higher `freq_cutoff` than a linear baseline.
 #
 # The various regularization parameters `lam_d` will be initially fixed, with their values set
-# according to the L1 norm of each d'th derivative, as suggested by the `original BEADS manuscript
-# <https://doi.org/10.1016/j.chemolab.2014.09.014>`_. This can be done manually, like so::
-#
-#     alpha = 1.
-#     lam_0 = alpha / abs(y_transf).sum()  # np.diff(y_transf, 0) == y_transf
-#     lam_1 = alpha / abs(np.diff(y_transf, 1)).sum()
-#     lam_2 = alpha / abs(np.diff(y_transf, 2)).sum()
-#
-# If using pybaselines version 1.3 or later, this can be done more simply by setting the
-# `alpha` parameter and leaving all `lam_d` values to their default values of ``None``,
-# which is what this example will do.
-cutoff_freqs = np.geomspace(1e-3, 0.4, 30)
-alpha = 1.
+# according to the L1 norm of each d'th derivative, as suggested by the `original BEADS paper
+# <https://doi.org/10.1016/j.chemolab.2014.09.014>`_.
+lam_0 = 1 / abs(y_transf).sum()  # np.diff(y_transf, 0) == y_transf
+lam_1 = 1 / abs(np.diff(y_transf, 1)).sum()
+lam_2 = 1 / abs(np.diff(y_transf, 2)).sum()
 
 plt.figure()
 plt.plot(y)
 r_squares = []
 min_mse = np.inf
+cutoff_freqs = np.geomspace(1e-3, 0.4, 30)
 for i, cutoff_freq in enumerate(cutoff_freqs):
     fit_transf, params = baseline_fitter.beads(
-        y_transf, freq_cutoff=cutoff_freq, alpha=alpha, **fixed_kwargs
+        y_transf, freq_cutoff=cutoff_freq, lam_0=lam_0, lam_1=lam_1, lam_2=lam_2
     )
     fit = np.exp(fit_transf) + min_y - 1
     r_squares.append(autocorrelation(y - fit))
@@ -126,56 +117,13 @@ ax.set_xlabel('Frequency cutoff')
 
 print(f'Best cutoff frequency: {cutoff_freqs[best_index]:.2e}')
 
-# %%
-# Visual inspection of the autocorrelation plot shows that the best cutoff frequency, selected
-# as the middle of the last plateau, occurs at ~0.01, which matches with the cutoff frequency
-# that produced the lowest mean squared error with the known baseline. Now, the cutoff
-# frequency can be fixed, and the optimal `alpha` value can be found.
-cutoff_freq = cutoff_freqs[best_index]
-alphas = np.geomspace(5e-4, 50000, 30)
-
-plt.figure()
-plt.plot(y)
-r_squares = []
-min_mse = np.inf
-for i, alpha in enumerate(alphas):
-    fit_transf, params = baseline_fitter.beads(
-        y_transf, alpha=alpha, freq_cutoff=cutoff_freq, **fixed_kwargs
-    )
-    fit = np.exp(fit_transf) + min_y - 1
-    r_squares.append(autocorrelation(y - fit))
-    if i % 6 == 0:
-        plt.plot(fit, '--', label=f'alpha={alpha:.1e}')
-    mse = ((fit - baseline)**2).mean()
-    if mse < min_mse:
-        best_index = i
-        min_mse = mse
-        best_fit = fit
-
-plt.legend()
-
-plt.figure()
-plt.plot(y)
-plt.plot(best_fit, '--', label='best fit')
-plt.plot(baseline, ':', label='true baseline')
-plt.legend()
-
-plt.figure()
-plt.plot(alphas, r_squares, 'o-')
-plt.plot(alphas[best_index], r_squares[best_index], 'ro', label='best fit')
-plt.legend()
-plt.semilogx()
-plt.ylabel(r'Autocorrelation, $r^2$')
-plt.xlabel('alpha')
-
-print(f'Best alpha: {alphas[best_index]:.2e}')
-
 plt.show()
 # %%
-# Again, visual inspection of the autocorrelation plot shows an optimal `alpha` value of
-# approximately 1, matching the fit that produces the lowest mean squared error with the
-# known baseline. It is unsurprising that the optimal `alpha` value is approximately 1
-# since the optimal `freq_cutoff` value was originally selected using a fixed value of
-# ``alpha=1``. Note that instead of varying `alpha`, each individual `lam_d` value could
-# be varied instead. As noted by Navarro-Huerta, J.A., et al., typically `lam_0` has
-# the highest influence of the three regularization parameters.
+# Visual inspection of the autocorrelation plot above suggests that the best cutoff frequency,
+# selected as the middle of the last plateau, occurs at ~0.01, which matches with the cutoff
+# frequency that produced the lowest mean squared error with the known baseline, labeled as
+# "best fit" in the plots above.
+#
+# As noted at the start of this example, this same procedure of finding plateaus on the
+# autocorrelation plot can be repeated to select appropriate values for other parameters
+# for `beads`, including `lam_0`, `lam_1`, `lam_2`, and `asymmetry`.

--- a/docs/examples/misc/plot_beads_param_selection.py
+++ b/docs/examples/misc/plot_beads_param_selection.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""
+Parameter Selection for `beads`
+-------------------------------
+
+This example examines the parameter selection criteria for :meth:`~pybaselines.Baseline.beads`
+proposed by `Navarro-Huerta, J.A., et al. "Assisted baseline subtraction in complex chromatograms
+using the BEADS algorithm" <https://doi.org/10.1016/j.chroma.2017.05.057>`_. Note that the
+preprocessing of data using a parabola before performing `beads` from the same paper is examined
+in  :ref:`another example <sphx_glr_generated_examples_misc_plot_beads_preprocessing.py>`.
+
+The proposed parameter selection process works by varying the parameter of interest (eg.
+`freq_cutoff`, `lam_0`, `lam_1`, etc.) and calculating the autocorrelation coefficient,
+:math:`r^2`, from the residual, ``data - baseline``, for each fit. The autocorrelation plots
+will show plateau regions in which the calculated baseline is fairly consistent with regards
+to the varying parameter. In theory, the optimal parameter value will then lie in the center of
+the last of these plateaus before :math:`r^2` approaches 0 (or some constant, minimum value).
+
+The example given here is fairly simple and illustrates how this parameter selection can be
+done visually; for a more in-depth analysis of automating this procedure for real chromatograms,
+see the `Weaselytics package <https://github.com/physicien/Weaselytics>`_.
+
+"""
+# sphinx_gallery_thumbnail_number = 3
+# sphinx_gallery_multi_image = "single"
+
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.inset_locator import mark_inset
+import numpy as np
+
+from pybaselines import Baseline
+from pybaselines.utils import make_data
+
+
+def autocorrelation(residual):
+    """Computes the autocorrelation of the residual following Navarro-Huerta, J.A., et al."""
+    diff_residual = np.diff(residual)
+    durbin_watson = (diff_residual @ diff_residual) / (residual @ residual)
+    return 0.25 * (2 - durbin_watson)**2
+
+
+x, y, baseline = make_data(return_baseline=True)
+baseline_fitter = Baseline(x)
+
+fixed_kwargs = {'tol': 1e-3, 'asymmetry': 6}
+
+# %%
+# Before varying any parameters, the input data will first be transformed by taking
+# the log of the input. The benefit of this transformation for `beads` is twofold:
+#
+# * As noted by Navarro-Huerta, J.A., et al., taking the log transform of the data
+#   helps to reduce ripples in the baseline when peaks have a significant magnitude
+#   difference compared to the baseline.
+#
+# * The regularization parameters for `beads` penalize the L1 norms, so they are not
+#   scale-invariant compared to methods like Whittaker smoothing which penalize the L2
+#   norm; this means that fitting ``y`` and ``100 * y`` would require changing the various
+#   `lam_d` parameters. Taking the log transform helps to put all data on the same
+#   relative scale such that the necessary regularization parameters between different
+#   datasets will not vary as much as long as other factors remain constant (eg. the number
+#   of points, baseline curvature, etc.).
+min_y = y.min()
+y_transf = np.log(y - min_y + 1)  # offset to ensure all values > 0 to prevent issues with log
+
+# %%
+# The first parameter to vary will be the cutoff frequency, `freq_cutoff`, since it typically
+# has the most influence on the baseline fit. A general rule of thumb is a higher cutoff
+# frequency is required for baselines with more curvature.
+#
+# The various regularization parameters `lam_d` will be initially fixed, with their values set
+# according to the L1 norm of each d'th derivative, as suggested by the `original BEADS manuscript
+# <https://doi.org/10.1016/j.chemolab.2014.09.014>`_. This can be done manually, like so::
+#
+#     alpha = 1.
+#     lam_0 = alpha / abs(y_transf).sum()  # np.diff(y_transf, 0) == y_transf
+#     lam_1 = alpha / abs(np.diff(y_transf, 1)).sum()
+#     lam_2 = alpha / abs(np.diff(y_transf, 2)).sum()
+#
+# If using pybaselines version 1.3 or later, this can be done more simply by setting the
+# `alpha` parameter and leaving all `lam_d` values to their default values of ``None``,
+# which is what this example will do.
+cutoff_freqs = np.geomspace(1e-3, 0.4, 30)
+alpha = 1.
+
+plt.figure()
+plt.plot(y)
+r_squares = []
+min_mse = np.inf
+for i, cutoff_freq in enumerate(cutoff_freqs):
+    fit_transf, params = baseline_fitter.beads(
+        y_transf, freq_cutoff=cutoff_freq, alpha=alpha, **fixed_kwargs
+    )
+    fit = np.exp(fit_transf) + min_y - 1
+    r_squares.append(autocorrelation(y - fit))
+    if i % 6 == 0:
+        plt.plot(fit, '--', label=f'cutoff_freq={cutoff_freq:.2e}')
+    mse = ((fit - baseline)**2).mean()
+    if mse < min_mse:
+        best_index = i
+        min_mse = mse
+        best_fit = fit
+
+plt.legend()
+
+plt.figure()
+plt.plot(y)
+plt.plot(best_fit, '--', label='best fit')
+plt.plot(baseline, ':', label='true baseline')
+plt.legend()
+
+fig, ax = plt.subplots()
+ax.plot(cutoff_freqs, r_squares, 'o-')
+ax.plot(cutoff_freqs[best_index], r_squares[best_index], 'ro', label='best fit')
+plt.legend()
+
+inset_ax = ax.inset_axes(
+    [0.15, 0.3, 0.5, 0.5], xlim=[8e-4, 0.07], ylim=[0.97, 1.02]
+)
+inset_ax.plot(cutoff_freqs, r_squares, 'o-')
+inset_ax.plot(cutoff_freqs[best_index], r_squares[best_index], 'ro')
+mark_inset(ax, inset_ax, loc1=1, loc2=2, alpha=0.5)
+ax.semilogx()
+inset_ax.semilogx()
+ax.set_ylabel(r'Autocorrelation, $r^2$')
+ax.set_xlabel('Frequency cutoff')
+
+print(f'Best cutoff frequency: {cutoff_freqs[best_index]:.2e}')
+
+# %%
+# Visual inspection of the autocorrelation plot shows that the best cutoff frequency, selected
+# as the middle of the last plateau, occurs at ~0.01, which matches with the cutoff frequency
+# that produced the lowest mean squared error with the known baseline. Now, the cutoff
+# frequency can be fixed, and the optimal `alpha` value can be found.
+cutoff_freq = cutoff_freqs[best_index]
+alphas = np.geomspace(5e-4, 50000, 30)
+
+plt.figure()
+plt.plot(y)
+r_squares = []
+min_mse = np.inf
+for i, alpha in enumerate(alphas):
+    fit_transf, params = baseline_fitter.beads(
+        y_transf, alpha=alpha, freq_cutoff=cutoff_freq, **fixed_kwargs
+    )
+    fit = np.exp(fit_transf) + min_y - 1
+    r_squares.append(autocorrelation(y - fit))
+    if i % 6 == 0:
+        plt.plot(fit, '--', label=f'alpha={alpha:.1e}')
+    mse = ((fit - baseline)**2).mean()
+    if mse < min_mse:
+        best_index = i
+        min_mse = mse
+        best_fit = fit
+
+plt.legend()
+
+plt.figure()
+plt.plot(y)
+plt.plot(best_fit, '--', label='best fit')
+plt.plot(baseline, ':', label='true baseline')
+plt.legend()
+
+plt.figure()
+plt.plot(alphas, r_squares, 'o-')
+plt.plot(alphas[best_index], r_squares[best_index], 'ro', label='best fit')
+plt.legend()
+plt.semilogx()
+plt.ylabel(r'Autocorrelation, $r^2$')
+plt.xlabel('alpha')
+
+print(f'Best alpha: {alphas[best_index]:.2e}')
+
+plt.show()
+# %%
+# Again, visual inspection of the autocorrelation plot shows an optimal `alpha` value of
+# approximately 1, matching the fit that produces the lowest mean squared error with the
+# known baseline. It is unsurprising that the optimal `alpha` value is approximately 1
+# since the optimal `freq_cutoff` value was originally selected using a fixed value of
+# ``alpha=1``. Note that instead of varying `alpha`, each individual `lam_d` value could
+# be varied instead. As noted by Navarro-Huerta, J.A., et al., typically `lam_0` has
+# the highest influence of the three regularization parameters.

--- a/docs/examples/misc/plot_beads_param_selection.py
+++ b/docs/examples/misc/plot_beads_param_selection.py
@@ -13,8 +13,9 @@ The proposed parameter selection process works by varying the parameter of inter
 `freq_cutoff`, `lam_0`, `lam_1`, etc.) and calculating the autocorrelation coefficient,
 :math:`r^2`, from the residual, ``data - baseline``, for each fit. The autocorrelation plots
 will show plateau regions in which the calculated baseline is fairly consistent with regards
-to the varying parameter. In theory, the optimal parameter value will then lie in the center of
-the last of these plateaus before :math:`r^2` approaches 0 (or some constant, minimum value).
+to the varying parameter. In theory, the optimal parameter value will then lie near the center of
+one of these plateaus (often the final one) before :math:`r^2` approaches 0 (or some constant,
+minimum value).
 
 The example given here is fairly simple and illustrates how this parameter selection can be
 done visually; for a more in-depth analysis of automating this procedure for real chromatograms,

--- a/docs/examples/misc/plot_beads_preprocessing.py
+++ b/docs/examples/misc/plot_beads_preprocessing.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 """
-Preprocessing for beads
------------------------
+Preprocessing for `beads`
+-------------------------
 
 The Baseline Estimation And Denoising with Sparsity (:meth:`~pybaselines.Baseline.beads`)
 algorithm is a robust method for both performing baseline subtraction and removing noise.
 One of the main drawbacks of the original algorithm is that it requires that both ends of
 the data to be at zero. This example will explore the consequences of this as
-well as a preprocessing step proposed by `Navarro-Huerta, J.A., et al. Assisted baseline
-subtraction in complex chromatograms using the BEADS algorithm. Journal of Chromatography
-A, 2017, 1507, 1-10` implemented in pybaselines that helps to address this issue.
+well as a preprocessing step proposed by `Navarro-Huerta, J.A., et al. "Assisted baseline
+subtraction in complex chromatograms using the BEADS
+algorithm" <https://doi.org/10.1016/j.chroma.2017.05.057>`_
+implemented in pybaselines that helps to address this issue.
 
 """
 # sphinx_gallery_thumbnail_number = 4


### PR DESCRIPTION
<!--Please fill out all sections of the pull request template.-->

### Description
<!--Describe the pull request in detail, telling why the changes
are required and/or what problems they fix. Link or add the issue number
for any existing issues that the pull request solves.

Note that it is preferred to file an issue first, so that details can be
discussed/finalized before a pull request is created.-->
Update of the documentation examples concerning the selection of BEADS parameters. These new examples are based on discussions with @derb12 following #70. For future reference, it was also decided that an additional example page might later be created to specifically cover optimization of the `alpha` parameter.

I slightly revised one of the paragraphs to clarify that, while the optimal value of `cutoff_frequency` will often appear on the last plateau, this is not guaranteed. Above all, I want to prevent users from automatically dismissing the possibility that the optimal value might lie on a different plateau, which can indeed occur in some situations, such as when the signal is short (e.g., when it contains fewer than 1000 data points).

I think that once this PR is merged, the `beads_example` branch can be merged into `development`.


### Type of Pull Request
<!--Put an x in all boxes that apply, like so: - [x] Bug Fix-->

- [ ] Bug Fix
- [ ] New Feature
- [ ] Miscellaneous Changes (refactor, code improvements, etc.)
- [x] Documentation or Example Programs

### Pull Request Checklist
<!--Fill in all boxes with an x to verify.

To run tests locally, type the following command within the pybaselines
directory: pytest .

To lint files using ruff to see if they pass PEP 8 standards and that
docstrings are okay, run the following command within the pybaselines
directory: ruff check .

To build documentation locally, type the following command within the
docs directory: make html
-->

- [x] New code and/or documentation is valid for use with the BSD 3-clause license.
- [ ] New code is fully documented with docstrings that follow Numpy style,
      if applicable.
- [ ] New code follows PEP 8 standards as closely as possible, if applicable.
- [ ] Added/updated tests and ensured they pass locally, if applicable.
- [x] Verified that documentation builds locally, if applicable.
